### PR TITLE
fix(graph to doc): fix bug in encode

### DIFF
--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -614,13 +614,12 @@ class ExportFile(object):
         delimiter = DELIMITERS[self.file_format]
         json_output, self.result = self.result, {}
 
-        def encode(k, v):
-            """Encode key/values for writing a tsv dict (see below)."""
-            if isinstance(k, unicode):
-                k = k.encode('utf-8')
-            if isinstance(v, unicode):
-                v = v.encode('utf-8')
-            return (k, v)
+        def encode(string):
+            """Encode keys or values for writing a tsv dict (see below)."""
+            if isinstance(string, unicode):
+                return string.encode('utf-8')
+            else:
+                return string
 
         for label, entities in json_output.iteritems():
             template = self.templates[label]
@@ -634,7 +633,7 @@ class ExportFile(object):
 
             for tsv_dict in get_tsv_dicts(entities, titles):
                 writer.writerow(
-                    {encode(k, v) for k, v in tsv_dict.iteritems()}
+                    {encode(k): encode(v) for k, v in tsv_dict.iteritems()}
                 )
 
     def get_delimited_response(self):


### PR DESCRIPTION
Fix bug introduced by mis-refactoring of the [gdcapi implementation](https://github.com/uc-cdis/gdcapi/blob/6fdde1995c45f9c977ecee0f86658166a1e81d72/gdcapi/resources/submission/transforms/gdc_graph2doc.py#L698-L700) in `ExportFile.get_tabular`.

R? @philloooo 