### PR TITLE
fix(export): backward compat with format

### DIFF
--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -286,6 +286,10 @@ def export_entities(program, project):
         kwargs = {k: v for k, v in flask.request.args.iteritems()}
     else:
         kwargs = utils.parse.parse_request_json()
+
+    if 'format' in kwargs:
+        kwargs['file_format'] = kwargs['format']
+        del kwargs['format']
     output = utils.transforms.graph_to_doc.ExportFile(
         program=program, project=project, **kwargs
     )


### PR DESCRIPTION
support `format` as the GET parameter for this endpoint https://github.com/NCI-GDC/gdcapi/blob/develop/gdcapi/resources/submission/transforms/gdc_graph2doc.py#L530

r? @rudyardrichter 