### PR TITLE
fix(index): only register new index if none exists

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pytest-cov==2.5.1
+codacy-coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ Flask-Cors==1.9.0
 Flask-SQLAlchemy-Session==1.1
 Flask==0.10.1
 fuzzywuzzy==0.6.1
-gdcapi==1.5.0
-gdcdatamodel==0.0.0
 graphene==0.10.2
 jsonschema==2.5.1
 lxml==3.8.0
@@ -19,3 +17,6 @@ sqlalchemy==0.9.9
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.1.5#egg=cdispyutils
 -e git+https://git@github.com/uc-cdis/userdatamodel.git@f25f5dfb356e80c45153ffd3e91b399be672a81c#egg=userdatamodel
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.1#egg=cdis_oauth2client
+-e git+https://git@github.com/NCI-GDC/cdisutils.git@8a8e599fdab5ade9bd8c586132d974a102e5d72d#egg=cdisutils
+-e git+https://git@github.com/uc-cdis/datadictionary.git@0.1.1#egg=gdcdictionary
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@44108de7b5aaabc33db6f39dda5130e1c2e0a3f6#egg=gdcdatamodel

--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -1,5 +1,4 @@
 import flask
-from gdcapi.errors import UserError
 
 from sheepdog import utils
 from sheepdog.globals import (

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -501,8 +501,8 @@ class UploadEntity(EntityBase):
           file, then do not create a new one.
         """
         project_id = self.transaction.project_id
-        submitter_id = self.node._props.get("submitter_id")
-        hashes = {'md5': self.node._props.get("md5sum")}
+        submitter_id = self.node._props.get('submitter_id')
+        hashes = {'md5': self.node._props.get('md5sum')}
         size = self.node._props.get('file_size')
         alias = "{}/{}".format(project_id, submitter_id)
         # Check if there is an existing record with this hash and size,

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -505,12 +505,15 @@ class UploadEntity(EntityBase):
         hashes = {'md5': self.node._props.get('md5sum')}
         size = self.node._props.get('file_size')
         alias = "{}/{}".format(project_id, submitter_id)
-        # Check if there is an existing record with this hash and size,
-        # i.e. this node already has an index record. Create a new record (with
+        # Check if there is an existing record with this hash and size, i.e.
+        # this node already has an index record. Create a new record (with
         # UUID) only if none was found.
         params = {'hashes': hashes, 'size': size}
-        ids = self.transaction.signpost._get('index', params=params)['ids']
-        if not ids:
+        # document: indexclient.Document
+        # if `document` exists, `document.did` is the UUID that is already
+        # registered in indexd for this entity.
+        document = self.transaction.signpost.get_with_params(params)
+        if not document:
             self.transaction.signpost.create(
                 did=str(uuid.uuid4()), hashes=hashes, size=size, urls=[]
             )

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -490,6 +490,34 @@ class UploadEntity(EntityBase):
         """
         return node.project_id == self.transaction.project_id
 
+    def register_index(self):
+        """
+        Call the "signpost" (index client) for the transaction to register a
+        new index record for this entity.
+
+        NOTE:
+        - Should only ever be called for data and metadata files.
+        - If there is already a record matching the hash and size for this
+          file, then do not create a new one.
+        """
+        project_id = self.transaction.project_id
+        submitter_id = self.node._props.get("submitter_id")
+        hashes = {'md5': self.node._props.get("md5sum")}
+        size = self.node._props.get('file_size')
+        alias = "{}/{}".format(project_id, submitter_id)
+        # Check if there is an existing record with this hash and size,
+        # i.e. this node already has an index record. Create a new record (with
+        # UUID) only if none was found.
+        params = {'hashes': hashes, 'size': size}
+        ids = self.transaction.signpost._get('index', params=params)['ids']
+        if not ids:
+            self.transaction.signpost.create(
+                did=str(uuid.uuid4()), hashes=hashes, size=size, urls=[]
+            )
+        self.transaction.signpost.create_alias(
+            record=alias, hashes=hashes, size=size, release='private'
+        )
+
     def flush_to_session(self):
         if not self.node:
             return
@@ -498,35 +526,23 @@ class UploadEntity(EntityBase):
         try:
             if role == 'create':
                 # Check if the category for the node is data_file or
-                # metadata_file, in which case, register a uuid and alias in
+                # metadata_file, in which case, register a UUID and alias in
                 # the index service.
                 cls = psqlgraph.Node.get_subclass(self.entity_type)
                 category = dictionary.schema.get(cls.label)['category']
-                is_data_file = category == 'data_file'
-                is_metadata_file = category == 'metadata_file'
-                if is_data_file or is_metadata_file:
-                    project_id = self.transaction.project_id
-                    submitter_id = self.node._props.get("submitter_id")
-                    hashes = {'md5': self.node._props.get("md5sum")}
-                    alias = "{}/{}".format(project_id, submitter_id)
-                    # ``self.transaction.signpost`` is an IndexClient instance
-                    # which supports creation of index and alias records.
-                    self.transaction.signpost.create(
-                        did=str(uuid.uuid4()), hashes=hashes, size=self.node._props.get('file_size'), urls=[]
-                    )
-                    self.transaction.signpost.create_alias(record=alias, hashes=hashes, size=self.node._props.get('file_size'), release='private')
+                if category == 'data_file' or category == 'metadata_file':
+                    self.register_index()
                 self.transaction.session.add(self.node)
             elif role == 'update':
                 self.node = self.transaction.session.merge(self.node)
             else:
-                message = 'Uknown role {}'.format(role)
+                message = 'Unknown role {}'.format(role)
                 self.logger.error(message)
                 self.record_error(
                     message, type=EntityErrors.INVALID_PERMISSIONS
                 )
         except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(e)
-            # FIXME: could leak unnecessary implementation details
             self.record_error(str(e))
 
     def get_skeleton_node(self, label, properties, project_id=None):

--- a/tests/test_vacuous.py
+++ b/tests/test_vacuous.py
@@ -1,0 +1,2 @@
+def test_vacuous():
+    assert True


### PR DESCRIPTION
Resolves #21.

If a file exists in the index service with the same size and hashes as a file being uploaded, do not create a new index record with a new UUID.