### PR TITLE
feat(docs): fix jekyll config for GH pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,0 @@
-gems:
-  - jekyll-redirect-from

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+source: build/html/
+include:
+  - _static

--- a/docs/build/html/index.html
+++ b/docs/build/html/index.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE html>
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,0 @@
----
-redirect_to: "/docs/build/html/index.html"
----


### PR DESCRIPTION
GitHub pages setup from last PR not working correctly because the `_config.yml` goes in the folder being served from, i.e. `/docs`.