### PR TITLE
fix(global): get rid of global variable

### DIFF
--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -551,7 +551,7 @@ class UploadEntity(EntityBase):
         return node.project_id == self.transaction.project_id
 
     def get_metadata(self):
-        metadata = {'acls': flask.g.dbgap_accession_numbers}
+        metadata = {'acls': self.transaction.get_phsids()}
         return metadata
 
     def register_index(self):


### PR DESCRIPTION
transaction has a way to get phsids/dbgap_accession_numbers, so use that
instead of messing with global flask variables