### PR TITLE
fix(deletion): Workaround for gdc dictionary broken required fields

### DIFF
--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from sheepdog import dictionary
 from sheepdog.errors import UserError
 from sheepdog.globals import (
@@ -90,6 +91,13 @@ class DeletionTransaction(TransactionBase):
                             [field in dictionary.schema[e.node.label][protected_category]
                              for protected_category in ['required', 'systemProperties']]
                         )
+                        # Below is a sad workaround for inconsistent gdcdictionary :|
+                        # Will be safe to remove once 'required' fields is a
+                        # complete and tested set for all node types in gdcdictionary.schemas
+                        if current_app.config.get('IS_GDC', True):
+                            if field in ['submitter_id', 'project_id', 'state', 'file_state']:
+                                field_is_protected = True
+
                         if field_is_protected:
                             raise UserError(
                                 'Unable to delete protected field "{}" in a {} node'


### PR DESCRIPTION
This is a temporary patch till `gdcdictionary.schemas[node_type]['required']` has everything that is actually required for each `node_type`