### PR TITLE
fix(logging): log real user id and ip addr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY . /sheepdog
 COPY ./deployment/uwsgi/uwsgi.ini /etc/uwsgi/uwsgi.ini
+COPY ./deployment/nginx/nginx.conf /etc/nginx/
 COPY ./deployment/nginx/uwsgi.conf /etc/nginx/sites-available/
 WORKDIR /sheepdog
 

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,0 +1,65 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+  log_format aws   '$http_x_forwarded_for - $http_x_userid [$time_local] '
+              '"$request" $status $body_bytes_sent '
+              '"$http_referer" "$http_user_agent"';
+	access_log /var/log/nginx/access.log aws;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+

--- a/deployment/nginx/uwsgi.conf
+++ b/deployment/nginx/uwsgi.conf
@@ -2,6 +2,9 @@ server {
     listen 80;
 
     location / {
+        uwsgi_param REMOTE_ADDR $http_x_forwarded_for if_not_empty;
+        uwsgi_param REMOTE_USER $http_x_userid if_not_empty;
+
         include uwsgi_params;
         uwsgi_pass unix:/var/www/sheepdog/uwsgi.sock;
         uwsgi_read_timeout 20s;

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -1,6 +1,7 @@
 [uwsgi]
 protocol = uwsgi
 socket = /var/www/sheepdog/uwsgi.sock
+buffer-size = 32768
 chmod-socket = 666
 master = true
 processes = 2

--- a/dockerrun.bash
+++ b/dockerrun.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 cd /var/www/sheepdog
-python wsgi.py
 
 (
   # Wait for nginx to create uwsgi.sock


### PR DESCRIPTION
integrate nginx logging and nginx uwsgi config
with X-Forwarded-For and X-UserId headers
supplied by the reverse proxy, so peregrine logs
have the client ip and user id

also increase uwsgi buffer-size - not happy with big headers
from jwt
http://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size

resolves #63