### PR TITLE
Feat/url to indexd

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ dictionaryutils
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.5#egg=cdispyutils
 -e git+https://git@github.com/uc-cdis/userdatamodel.git@1.0.4#egg=userdatamodel
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
--e git+https://git@github.com/uc-cdis/indexclient.git@13e5a5c8bf8a52acd3aa6a1b9ce9669b3e7ffb8d#egg=indexclient
+-e git+https://git@github.com/uc-cdis/indexclient.git@1.3.2#egg=indexclient
 -e git+https://git@github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 # required for gdcdatamodel, not required for sheepdog
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ dictionaryutils
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.5#egg=cdispyutils
 -e git+https://git@github.com/uc-cdis/userdatamodel.git@1.0.4#egg=userdatamodel
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
--e git+https://git@github.com/uc-cdis/indexclient.git@1.2.1#egg=indexclient
+-e git+https://git@github.com/uc-cdis/indexclient.git@13e5a5c8bf8a52acd3aa6a1b9ce9669b3e7ffb8d#egg=indexclient
 -e git+https://git@github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 # required for gdcdatamodel, not required for sheepdog
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils

--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -27,7 +27,7 @@ from sheepdog.globals import (
     STATES_COMITTABLE_DRY_RUN,
 )
 from sheepdog.transactions import upload
-from sheepdog.transactions.upload.entity import UploadEntity
+from sheepdog.transactions.upload.entity_factory import UploadEntityFactory
 from sheepdog.transactions.upload.transaction import UploadTransaction
 
 
@@ -192,7 +192,8 @@ def create_project(program):
         with UploadTransaction(**transaction_args) as trans:
             node = session.merge(node)
             session.commit()
-            entity = UploadEntity(trans, flask.current_app.config)
+            entity = UploadEntityFactory.create(
+                trans, doc=None, config=flask.current_app.config)
             entity.action = action
             entity.doc = doc
             entity.entity_type = 'project'

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -1,8 +1,6 @@
-# pylint: disable=protected-access
 """
-TODO
+Classes and functions for upload.
 """
-
 import uuid
 
 import psqlgraph
@@ -50,6 +48,7 @@ class UploadEntity(EntityBase):
     create a node. After this, it should be flushed into a UploadTransaction's
     session.
     """
+    DATA_FILE_CATEGORIES = ['data_file', 'metadata_file']
 
     def __init__(self, transaction, config=None):
         """
@@ -61,9 +60,6 @@ class UploadEntity(EntityBase):
         self.parents = {}
         self._secondary_keys = None
         self._config = config
-        self.url = None
-        self.file_exists = False
-        self.file_index = None
 
     @property
     def secondary_keys(self):
@@ -92,62 +88,6 @@ class UploadEntity(EntityBase):
         node = self.node or self.get_skeleton_node(self.entity_type, self.doc)
         return [] if not node else node.__pg_secondary_keys
 
-    @staticmethod
-    def is_file(node):
-        """
-        Check if the API should treat this node as a file-like object.
-
-        Args:
-            node (psqlgraph.Node):
-
-        Return:
-            bool
-        """
-        is_category_data_file = (
-            node._dictionary['category'] == 'data_file'
-            or node._dictionary['category'] == 'metadata_file')
-        has_file_state = 'file_state' in node.__pg_properties__
-        return is_category_data_file and has_file_state
-
-    def _get_category(self):
-        """
-        Return the current category specified for this entity
-        """
-        cls = psqlgraph.Node.get_subclass(self.entity_type)
-        category = dictionary.schema.get(cls.label)['category']
-        return category
-
-    def _is_file_category(self):
-        """
-        Return whether the current category specified for this entity
-        is a file.
-        """
-        category = self._get_category()
-        return category == 'data_file' or category == 'metadata_file'
-
-    @staticmethod
-    def is_updatable_file(node):
-        """
-        Check that a node is a file that can be updated. True if:
-
-        #. The node is a data_file
-        #. It has a file_state in the list of states below
-
-        Args:
-            node (psqlgraph.Node):
-
-        Return:
-            bool: whether the node is an updatable file
-        """
-        allowed_states = [
-            'registered',
-            'uploading',
-            'uploaded',
-            'validating',
-        ]
-        file_state = node._props.get('file_state')
-        return UploadEntity.is_file(node) and file_state in allowed_states
-
     def parse(self, doc):
         """
         Parse the given doc and set the instance values accordingly.
@@ -166,20 +106,15 @@ class UploadEntity(EntityBase):
             )
 
         self.doc = doc
-        # If a url is included, get it here and remove it from doc so it
-        # doesn't get validated
-        entity_url = doc.get('url')
-        if entity_url:
-            self.url = entity_url
-            # remove from the doc since we don't want to validate it
-            doc.pop('url')
-
         self._parse_type()
         if self.entity_type and self.is_valid:
             self._parse_id()
 
     def instantiate(self):
-
+        """
+        Create the graph node by populating necessary information within this
+        instance. Will actually be added when flushed to the session.
+        """
         if not self.is_valid:
             return
 
@@ -207,9 +142,9 @@ class UploadEntity(EntityBase):
             return
 
         if self.transaction.role == 'create':
-            self.node = self._get_node_create()
+            self.node = self.get_node_create()
         elif self.transaction.role == 'update':
-            self.node = self._get_node_merge()
+            self.node = self.get_node_merge()
         else:
             self.record_error(
                 "Unknown role '{}'".format(self.transaction.role),
@@ -224,47 +159,18 @@ class UploadEntity(EntityBase):
         self._set_node_properties()
 
     def flush_to_session(self):
+        """
+        Add graph node to session of the current transaction.
+        """
         if not self.node:
             return
 
         role = self.action
         try:
             if role == 'create':
-                # ################################################################
-                # SignpostClient is used instead of IndexClient for the GDCAPI.
-                # This means that the client doesn't have access to IndexClient's
-                # methods, causing exceptions to occur.
-                #
-                # Temporary workaround until gdcapi uses indexd
-                # ################################################################
-                if self._config.get('USE_SIGNPOST', False):
-                    pass
-                else:
-                    # Check if the category for the node is data_file or
-                    # metadata_file, in which case, register a UUID and alias in
-                    # the index service.
-                    if self._is_file_category() and not self.file_exists:
-                        self._register_index()
-
                 self.transaction.session.add(self.node)
             elif role == 'update':
                 self.node = self.transaction.session.merge(self.node)
-
-                # ################################################################
-                # SignpostClient is used instead of IndexClient for the GDCAPI.
-                # This means that the client doesn't have access to IndexClient's
-                # methods, causing exceptions to occur.
-                #
-                # Temporary workaround until gdcapi uses indexd
-                # ################################################################
-                if self._config.get('USE_SIGNPOST', False):
-                    pass
-                else:
-                    # Check if the category for the node is data_file or
-                    # metadata_file, in which case, register a UUID and alias in
-                    # the index service.
-                    if self._is_file_category() and self.file_exists:
-                        self._update_index()
             else:
                 message = 'Unknown role {}'.format(role)
                 self.logger.error(message)
@@ -309,7 +215,7 @@ class UploadEntity(EntityBase):
             )
         self._validate_type()
 
-    def _get_node_create(self, skip_node_lookup=False):
+    def get_node_create(self, skip_node_lookup=False):
         """
         This is called for a POST operation.
 
@@ -355,29 +261,6 @@ class UploadEntity(EntityBase):
                         keys=['submitter_id'],
                         type=EntityErrors.NOT_FOUND)
 
-        if self._is_file_category():
-            # ################################################################
-            # SignpostClient is used instead of IndexClient for the GDCAPI.
-            # This means that the client doesn't have access to IndexClient's
-            # methods, causing exceptions to occur.
-            #
-            # Temporary workaround until gdcapi uses indexd
-            # ################################################################
-            if self._config.get('USE_SIGNPOST', False):
-                if self.entity_id:
-                    self.record_error(
-                        'Cannot assign ID to file, these are system generated. ',
-                        keys=['id'],
-                        type=EntityErrors.INVALID_VALUE,
-                    )
-                else:
-                    doc = self._create_index()
-                    self.entity_id = doc.did
-                    self.file_exists = True
-            else:
-                self._check_index_for_file()
-                self._set_node_and_file_ids()
-
         if not self.entity_id:
             self.entity_id = str(uuid.uuid4())
 
@@ -406,14 +289,12 @@ class UploadEntity(EntityBase):
         cls = psqlgraph.Node.get_subclass(self.entity_type)
         self.logger.debug('Creating new {}'.format(cls.__name__))
         node = cls(self.entity_id)
-        if self._is_file_category():
-            node.acl = self.transaction.get_phsids()
 
         self.action = 'create'
 
         return node
 
-    def _get_node_merge(self):
+    def get_node_merge(self):
         """
         This is called for a PATCH operation and supports upsert. It will
         lookup an existing node or create one if it doesn't exist.
@@ -428,29 +309,6 @@ class UploadEntity(EntityBase):
             self.secondary_keys
         ).all()
 
-        # ################################################################
-        # SignpostClient is used instead of IndexClient for the GDCAPI.
-        # This means that the client doesn't have access to IndexClient's
-        # methods, causing exceptions to occur.
-        #
-        # Temporary workaround until gdcapi uses indexd
-        # ################################################################
-        if self._config.get('USE_SIGNPOST', False):
-            pass
-        else:
-            # check to see if file exists in index service if it exists in graph
-            if len(nodes) == 1:
-                if self._is_file_category():
-                    self._check_index_for_file(nodes[0].node_id)
-                    if self.file_exists and self.file_index != nodes[0].node_id:
-                        return self.record_error(
-                            'Graph ID and file id in index service do not match, '
-                            'which is currently not permitted. Graph ID: {}. '
-                            'Index ID: {}.'
-                            .format(nodes[0].node_id, self.file_index),
-                            type=EntityErrors.NOT_UNIQUE,
-                        )
-
         if len(nodes) > 1:
             return self.record_error(
                 'Entity is not unique, {} entities found with {}'
@@ -460,7 +318,7 @@ class UploadEntity(EntityBase):
 
         # If no node was found, create a new one
         if len(nodes) == 0:
-            return self._get_node_create()
+            return self.get_node_create()
 
         # Check user permissions for updating nodes
         if 'update' not in self.get_user_roles():
@@ -496,18 +354,6 @@ class UploadEntity(EntityBase):
                 type=EntityErrors.NOT_UNIQUE,
             )
 
-        # If the node is a data_file, verify that update is allowed
-        if self.is_file(node) and not self.is_updatable_file(node):
-            self.record_error(
-                ("This file is already in file_state '{}' and cannot be "
-                 "updated. The raw data exists in the file storage "
-                 "and modifying the Entity now is unsafe and may cause "
-                 "problems for any processes or users consuming "
-                 "this data.").format(node._props.get('file_state')),
-                keys=['file_state'],
-                type=EntityErrors.INVALID_PERMISSIONS,
-            )
-
         # Since we are updating the node, we have to set its state to
         # ``validated``.  This means that this version of the node has
         # not been submitted and will not be displayed on the portal.
@@ -535,226 +381,6 @@ class UploadEntity(EntityBase):
         self.entity_id = node.node_id
 
         return node
-
-    def _check_index_for_file(self, uuid=None):
-        """
-        Populate information about file existence in index service.
-        Will first check provided uuid, then check by hash/size.
-
-        Returns:
-            TYPE: Description
-        """
-        file_by_hash = self.get_file_from_index_by_hash()
-        file_by_uuid = self.get_file_from_index_by_uuid(uuid)
-
-        indexed_file = file_by_uuid or file_by_hash or None
-
-        if indexed_file:
-            self.file_index = indexed_file.did
-            self.file_exists = True
-
-    def _set_node_and_file_ids(self):
-        """
-        Set the node uuid and indexed file uuid accordingly based on
-        information provided and whether or not the file exists in the
-        index service.
-        """
-        if self.entity_id and not self.file_exists:
-            # use entity_id for file creation
-            self.file_index = self.entity_id
-        elif self.entity_id and self.file_exists:
-            # check to make sure that when file exists
-            # and an id is provided that they are the same
-            if not self._is_valid_index_for_file(self.entity_id):
-                # record errors are populated in check above
-                return
-        elif not self.entity_id and not self.file_exists:
-            # use same id for both node entity id and file index
-            self.entity_id = str(uuid.uuid4())
-            self.file_index = self.entity_id
-        elif not self.entity_id and self.file_exists:
-            # the file exists in indexd and
-            # no node id is provided, so use indexd id
-            self.entity_id = self.file_index
-        else:
-            pass
-
-    def _is_valid_index_for_file(self, uuid):
-        """
-        Return whether or not uuid provided matches hash/size for file in index.
-
-        Will first check for an indexed file with provided hash/size.
-        Will then check for file with given uuid. Then will make sure
-        those uuids match. record_errors will be set with any issues
-        """
-        is_valid = True
-
-        # ################################################################
-        # SignpostClient is used instead of IndexClient for the GDCAPI.
-        # This means that the client doesn't have access to IndexClient's
-        # methods, causing exceptions to occur.
-        #
-        # Temporary workaround until gdcapi uses indexd
-        # ################################################################
-        if self._config.get('USE_SIGNPOST', False):
-            file_by_uuid = self.get_file_from_index_by_uuid(uuid)
-            if not file_by_uuid:
-                self.record_error(
-                    "Could not find file in index with ID: {}".format(uuid),
-                    type=EntityErrors.INVALID_VALUE
-                )
-                is_valid = False
-        else:
-            file_by_hash = self.get_file_from_index_by_hash()
-            file_by_uuid = self.get_file_from_index_by_uuid(uuid)
-
-            if not file_by_hash or not file_by_uuid:
-                error_message = (
-                    'Could not find exact file match in index for id: {} '
-                    'AND `hashes - size`: `{} - {}`. '
-                ).format(
-                    self.entity_id,
-                    str(self._get_file_hashes()),
-                    str(self._get_file_size())
-                )
-
-                if file_by_hash:
-                    error_message += 'A file was found matching `hash / size` but NOT id.'
-                elif file_by_uuid:
-                    error_message += 'A file was found matching id but NOT `hash / size`.'
-                else:
-                    # keep generic error message since both didn't result in a match
-                    pass
-
-                self.record_error(
-                    error_message,
-                    type=EntityErrors.INVALID_VALUE
-                )
-                is_valid = False
-
-            if file_by_hash and file_by_uuid and file_by_hash.did != file_by_uuid.did:
-                # both exist but dids are different
-                # FIXME: error should be handled different/removed
-                #        when we support updating indexed files
-                self.record_error(
-                    'Given id for indexed file {} does not match the id '
-                    'for the file discovered in the index by hash/size ('
-                    'id: {}). Updating a previous index with new file '
-                    'is currently NOT SUPPORTED.'
-                    .format(file_by_uuid.did, file_by_hash.did),
-                    type=EntityErrors.INVALID_VALUE,
-                )
-                is_valid = False
-
-        return is_valid
-
-    def get_file_from_index_by_hash(self):
-        """
-        Return the record entity from "signpost" (index client)
-
-        NOTE:
-        - Should only ever be called for data and metadata files.
-        - If there is already a record matching the hash and size for this
-          file, then return none.
-        """
-        document = None
-
-        # ################################################################
-        # SignpostClient is used instead of IndexClient for the GDCAPI.
-        # This means that the client doesn't have access to IndexClient's
-        # methods, causing exceptions to occur.
-        #
-        # Temporary workaround until gdcapi uses indexd
-        # ################################################################
-        if not self._config.get('USE_SIGNPOST', False):
-            # Check if there is an existing record with this hash and size, i.e.
-            # this node already has an index record.
-            params = self._get_file_hashes_and_size()
-            # document: indexclient.Document
-            # if `document` exists, `document.did` is the UUID that is already
-            # registered in indexd for this entity.
-            document = self.transaction.signpost.get_with_params(params)
-
-        return document
-
-    def get_file_from_index_by_uuid(self, uuid):
-        """
-        Return the record entity from "signpost" (index client)
-
-        NOTE:
-        - Should only ever be called for data and metadata files.
-        - If there is already a record matching the hash and size for this
-          file, then return none.
-        """
-        document = None
-
-        if uuid:
-            document = self.transaction.signpost.get(uuid)
-
-        return document
-
-    def _get_file_hashes_and_size(self):
-        hashes = self._get_file_hashes()
-        size = self._get_file_size()
-        return {'hashes': hashes, 'size': size}
-
-    def _get_file_hashes(self):
-        return {'md5': self.doc.get('md5sum')}
-
-    def _get_file_size(self):
-        size = self.doc.get('file_size')
-        return size
-
-    def _register_index(self):
-        """
-        Call the "signpost" (index client) for the transaction to register a
-        new index record for this entity.
-
-        NOTE:
-        - Should only ever be called for data and metadata files
-          where the index record does NOT already exist
-        """
-        project_id = self.transaction.project_id
-        submitter_id = self.node._props.get('submitter_id')
-        hashes = {'md5': self.node._props.get('md5sum')}
-        size = self.node._props.get('file_size')
-        alias = "{}/{}".format(project_id, submitter_id)
-
-        urls = []
-        if self.url:
-            urls.append(self.url)
-
-        # IndexClient
-        self._create_index(did=self.file_index,
-                           hashes=hashes,
-                           size=size,
-                           urls=urls)  # TODO add metadata
-
-        self._create_alias(
-            record=alias, hashes=hashes, size=size, release='private'
-        )
-
-    def _update_index(self):
-        """
-        Call the "signpost" (index client) for the transaction to update an
-        index record for this entity.
-
-        NOTE:
-        - Should only ever be called for data and metadata files
-          where the index record does ALREADY exists
-        """
-        if self._is_valid_index_for_file(self.file_index):
-            document = self.get_file_from_index_by_uuid(self.file_index)
-
-            if self.url and self.url not in document.urls:
-                document.urls.append(self.url)
-                document.patch()
-
-    def _create_alias(self, **kwargs):
-        self.transaction.signpost.create_alias(**kwargs)
-
-    def _create_index(self, **kwargs):
-        self.transaction.signpost.create(**kwargs)
 
     def _merge_doc_links(self, node):
         """
@@ -921,10 +547,6 @@ class UploadEntity(EntityBase):
             bool: if existing node belongs to the correct project
         """
         return node.project_id == self.transaction.project_id
-
-    def get_metadata(self):
-        metadata = {'acls': flask.g.dbgap_accession_numbers}
-        return metadata
 
     def get_skeleton_node(self, label, properties, project_id=None):
         """

--- a/sheepdog/transactions/upload/entity_factory.py
+++ b/sheepdog/transactions/upload/entity_factory.py
@@ -1,0 +1,52 @@
+"""
+Class Factory for creating new upload entities
+"""
+import psqlgraph
+
+from sheepdog.transactions.upload.entity import UploadEntity
+from sheepdog.transactions.upload.sub_entities import NonFileUploadEntity
+from sheepdog.transactions.upload.sub_entities import FileUploadEntity
+
+
+def get_node_category(node_type):
+    """
+    Get the category for the given node type specified
+
+    Args:
+        node_type (str): the type of node
+
+    Returns:
+        str: node category
+    """
+    cls = psqlgraph.Node.get_subclass(node_type)
+    return cls._dictionary.get('category')
+
+
+class UploadEntityFactory():
+    """
+    Class factory for creating new upload entities based on the
+    attributes specified in the given doc.
+    """
+    @staticmethod
+    def create(transaction, doc, config=None):
+        """
+        Will attempt to parse the  type from the doc and check the dictionary
+        for that node type's category.
+
+        Will then return an instance of UploadEntity or one of its
+        subclasses based on the discovered category.
+        """
+        if not isinstance(doc, dict):
+            # We cannot determine category, just create base class
+            # NOTE: This error with doc will get recorded using record_error()
+            #       when the parse() function gets called to support
+            #       more helpful debugging
+            return UploadEntity(transaction, config)
+
+        node_type = doc.get('type')
+        node_category = get_node_category(node_type)
+
+        if node_category in UploadEntity.DATA_FILE_CATEGORIES:
+            return FileUploadEntity(transaction, config)
+        else:
+            return NonFileUploadEntity(transaction, config)

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -38,6 +38,44 @@ class FileUploadEntity(UploadEntity):
        #. pre_validate
        #. instantiate
        #. post_validate
+
+    Some things to note about data files and the index service:
+    - submitter_id/project should be unique per graph node
+    - submitter_id/project are used to create an alias in the index service to
+        a data file
+    - when sheepdog attempts to find out if a file exists in index service it
+      has TWO methods of determining
+        FIXME At the moment, there is a 1:1 mapping of id's between graph nodes and
+              indexed files. eventually, there'll be a file_id attr in the graph node
+        1) If a file uuid exists in the graph node or is provided in the submission,
+           we can look up that uuid in index service
+        2) The hash/file_size combo should be unique in the index service for each
+           file
+
+    Here are a few submission examples and how we currently handle. The
+    examples here refer to whether or not an "id" field is included during
+    the submission.
+
+    - "id" NOT provided , file NOT in index service
+        - A new uuid is generated and used for both the graph and indexed file
+
+    - "id" NOT provided , file in index service
+        - uuid from the file in the index service is used for the graph id
+
+    - "id" provided     , file NOT in index service
+        - id provided is used for the indexed file
+
+    - "id" provided     , file in index service
+        - Make sure the uuids match
+
+    ERROR cases handled:
+        - If you attempt to submit the same data again with a different "id"
+            it will fail. At the moment we are maintaining a 1:1 between indexed
+            files and graph nodes
+        - Attempting to submit new data (new file) when the node has already
+            been created with a previous file will fail. We don't currently
+            allow updating the linkage to a new file since we're forcing
+            a 1:1 between uuids in graph and index service
     """
     def __init__(self, *args, **kwargs):
         super(FileUploadEntity, self).__init__(*args, **kwargs)

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -1,0 +1,452 @@
+"""
+Subclasses for UploadEntity that handle different types of
+uploaded entites.
+"""
+import uuid
+import flask
+
+from sheepdog.transactions.entity_base import EntityErrors
+
+from sheepdog.transactions.upload.entity import UploadEntity
+from sheepdog.transactions.upload.entity import lookup_node
+
+
+class NonFileUploadEntity(UploadEntity):
+    """
+    Deals with non-file-like entities.
+
+    At the moment, there is no non-file specific logic for upload entities.
+
+    This was created for clarity and future extensibility in the case that
+    non-file-like upload entity logic is required.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(NonFileUploadEntity, self).__init__(*args, **kwargs)
+
+
+class FileUploadEntity(UploadEntity):
+    """
+    Deals with file-like entities.
+
+    As such, this class extends the general UploadEntity class by
+    handling the interaction to the index service.
+
+    Like it's parent class:
+    The lifespan of a FileUploadEntity should include:
+       #. parse
+       #. pre_validate
+       #. instantiate
+       #. post_validate
+    """
+    def __init__(self, *args, **kwargs):
+        super(FileUploadEntity, self).__init__(*args, **kwargs)
+        self.file_exists = False
+        self.file_index = None
+        self.file_by_uuid = None
+        self.file_by_hash = None
+        self.urls = []
+
+    def parse(self, doc):
+        """
+        Parse the given doc and set the instance values accordingly.
+
+        Args:
+            doc (dict): the json upload representation
+
+        Return:
+            None
+        """
+        # If a url is included, get it here and remove it from doc so it
+        # doesn't get validated
+        entity_urls = doc.get('urls')
+        if entity_urls:
+            self.urls = entity_urls.strip().split(',')
+            # remove from the doc since we don't want to validate it
+            doc.pop('urls')
+
+        super(FileUploadEntity, self).parse(doc)
+
+    def get_node_create(self, skip_node_lookup=False):
+        """
+        This is called for a POST operation.
+
+        Return:
+            psqlgraph.Node
+        """
+        # ################################################################
+        # SignpostClient is used instead of IndexClient for the GDCAPI.
+        # This means that the client doesn't have access to IndexClient's
+        # methods, causing exceptions to occur.
+        #
+        # Temporary workaround until gdcapi uses indexd
+        # ################################################################
+        if self._config.get('USE_SIGNPOST', False):
+            if self.entity_id:
+                self.record_error(
+                    'Cannot assign ID to file, these are system generated. ',
+                    keys=['id'],
+                    type=EntityErrors.INVALID_VALUE,
+                )
+            else:
+                doc = self._create_index()
+                self.entity_id = doc.did
+                self.file_exists = True
+        else:
+            self._check_index_for_file(self.entity_id)
+            self._set_node_and_file_ids()
+
+        # call to super must happen after setting node and file ids here
+        node = super(FileUploadEntity, self).get_node_create(
+            skip_node_lookup=skip_node_lookup)
+        node.acl = self.transaction.get_phsids()
+
+        return node
+
+    def get_node_merge(self):
+        """
+        This is called for a PATCH operation and supports upsert. It will
+        lookup an existing node or create one if it doesn't exist.
+
+        Return:
+            psqlgraph.Node:
+        """
+        # entity_id is set to the node_id here
+        node = super(FileUploadEntity, self).get_node_merge()
+
+        # verify that update is allowed
+        if not self.is_updatable_file_node(node):
+            self.record_error(
+                ("This file is already in file_state '{}' and cannot be "
+                 "updated. The raw data exists in the file storage "
+                 "and modifying the Entity now is unsafe and may cause "
+                 "problems for any processes or users consuming "
+                 "this data.").format(node._props.get('file_state')),
+                keys=['file_state'],
+                type=EntityErrors.INVALID_PERMISSIONS,
+            )
+
+        # ################################################################
+        # SignpostClient is used instead of IndexClient for the GDCAPI.
+        # This means that the client doesn't have access to IndexClient's
+        # methods, causing exceptions to occur.
+        #
+        # Temporary workaround until gdcapi uses indexd
+        # ################################################################
+        if self._config.get('USE_SIGNPOST', False):
+            pass
+        else:
+            self._check_index_for_file(self.entity_id)
+            self._is_valid_index_id_for_graph()
+
+        return node
+
+    def flush_to_session(self):
+        """
+        Depending on the role and status of the file in the index service,
+        register or update an index. Then call parent class's
+        flush_to_session.
+        """
+
+        # ################################################################
+        # SignpostClient is used instead of IndexClient for the GDCAPI.
+        # This means that the client doesn't have access to IndexClient's
+        # methods, causing exceptions to occur.
+        #
+        # Temporary workaround until gdcapi uses indexd
+        # ################################################################
+        if self._config.get('USE_SIGNPOST', False):
+            pass
+        else:
+            if not self.node:
+                return
+
+            role = self.action
+            try:
+                if role == 'create':
+                    # Check if the category for the node is data_file or
+                    # metadata_file, in which case, register a UUID and alias in
+                    # the index service.
+                    if not self.file_exists:
+                        self._register_index()
+
+                elif role == 'update':
+                    # Check if the category for the node is data_file or
+                    # metadata_file, in which case, register a UUID and alias in
+                    # the index service.
+                    if self.file_exists:
+                        self._update_index()
+                else:
+                    message = 'Unknown role {}'.format(role)
+                    self.logger.error(message)
+                    self.record_error(
+                        message, type=EntityErrors.INVALID_PERMISSIONS
+                    )
+            except Exception as e:
+                self.logger.exception(e)
+                self.record_error(str(e))
+
+        # next do node creation
+        super(FileUploadEntity, self).flush_to_session()
+
+    def _register_index(self):
+        """
+        Call the "signpost" (index client) for the transaction to register a
+        new index record for this entity.
+        """
+        project_id = self.transaction.project_id
+        submitter_id = self.node._props.get('submitter_id')
+        hashes = {'md5': self.node._props.get('md5sum')}
+        size = self.node._props.get('file_size')
+        alias = "{}/{}".format(project_id, submitter_id)
+        metadata = self.get_metadata()
+
+        urls = []
+        if self.urls:
+            urls.extend(self.urls)
+
+        # IndexClient
+        self._create_index(did=self.file_index,
+                           hashes=hashes,
+                           size=size,
+                           urls=urls,
+                           metadata=metadata)
+
+        self._create_alias(
+            record=alias, hashes=hashes, size=size, release='private'
+        )
+
+    def _update_index(self):
+        """
+        Call the "signpost" (index client) for the transaction to update an
+        index record for this entity.
+        """
+        document = self.file_by_uuid
+
+        if self.urls:
+            urls_to_add = [url for url in self.urls if url not in document.urls]
+            if urls_to_add:
+                document.urls.extend(urls_to_add)
+                document.patch()
+
+    @staticmethod
+    def is_updatable_file_node(node):
+        """
+        Check that a node is a file that can be updated. True if:
+
+        #. The node is a data_file
+        #. It has a file_state in the list of states below
+
+        Args:
+            node (psqlgraph.Node):
+
+        Return:
+            bool: whether the node is an updatable file
+        """
+        is_updateable = True
+        has_file_state = 'file_state' in node.__pg_properties__
+
+        if has_file_state:
+            allowed_states = [
+                'registered',
+                'uploading',
+                'uploaded',
+                'validating',
+            ]
+            file_state = node._props.get('file_state')
+            if file_state and file_state not in allowed_states:
+                is_updateable = False
+
+        return is_updateable
+
+    def _check_index_for_file(self, uuid=None):
+        """
+        Populate information about file existence in index service.
+        Will first check provided uuid, then check by hash/size.
+
+        Returns:
+            TYPE: Description
+        """
+        self.file_by_hash = self.get_file_from_index_by_hash()
+        self.file_by_uuid = self.get_file_from_index_by_uuid(uuid)
+
+        if self.file_by_uuid or self.file_by_hash:
+            self.file_exists = True
+
+    def _set_node_and_file_ids(self):
+        """
+        Set the node uuid and indexed file uuid accordingly based on
+        information provided and whether or not the file exists in the
+        index service.
+        """
+        if not self.file_exists:
+            if self.entity_id:
+                # use entity_id for file creation
+                self.file_index = self.entity_id
+            else:
+                # use same id for both node entity id and file index
+                self.entity_id = str(uuid.uuid4())
+                self.file_index = self.entity_id
+        else:
+            if self.entity_id:
+                # check to make sure that when file exists
+                # and an id is provided that they are the same
+                # NOTE: record errors are populated in check below
+                self._is_valid_index_for_file()
+            else:
+                # the file exists in indexd and
+                # no node id is provided, so attempt to use indexed id
+                file_by_hash_index = getattr(self.file_by_hash, 'did', None)
+
+                # ensure that the index we found matches the graph (this will
+                # populate record errors if there are any issues)
+                if self._is_valid_index_id_for_graph():
+                    self.entity_id = file_by_hash_index
+
+    def _is_valid_index_for_file(self):
+        """
+        Return whether or not uuid provided matches hash/size for file in index.
+
+        Will first check for an indexed file with provided hash/size.
+        Will then check for file with given uuid. Then will make sure
+        those uuids match. record_errors will be set with any issues
+        """
+        is_valid = True
+
+        if not self.file_by_hash or not self.file_by_uuid:
+            error_message = (
+                'Could not find exact file match in index for id: {} '
+                'AND `hashes - size`: `{} - {}`. '
+            ).format(
+                self.entity_id,
+                str(self._get_file_hashes()),
+                str(self._get_file_size())
+            )
+
+            if self.file_by_hash:
+                error_message += 'A file was found matching `hash / size` but NOT id.'
+            elif self.file_by_uuid:
+                error_message += 'A file was found matching id but NOT `hash / size`.'
+            else:
+                # keep generic error message since both didn't result in a match
+                pass
+
+            self.record_error(
+                error_message,
+                type=EntityErrors.INVALID_VALUE
+            )
+            is_valid = False
+
+        if (self.file_by_hash and self.file_by_uuid and
+                self.file_by_hash.did != self.file_by_uuid.did):
+            # both exist but dids are different
+            # FIXME: error should be handled different/removed
+            #        when we support updating indexed files
+            self.record_error(
+                'Provided id for indexed file {} does not match the id '
+                'for the file discovered in the index by hash/size ('
+                'id: {}). Updating a previous index with new file '
+                'is currently NOT SUPPORTED.'
+                .format(self.file_by_uuid.did, self.file_by_hash.did),
+                type=EntityErrors.INVALID_VALUE,
+            )
+            is_valid = False
+
+        if is_valid:
+            is_valid = self._is_valid_index_id_for_graph()
+
+        return is_valid
+
+    def _is_valid_index_id_for_graph(self):
+        is_valid = True
+        # if a single match exists in the graph, check to see if
+        # file exists in index service
+        nodes = lookup_node(
+            self.transaction.db_driver,
+            self.entity_type,
+            self.entity_id,
+            self.secondary_keys
+        ).all()
+        if len(nodes) == 1:
+            if self.file_exists:
+                file_by_uuid_index = getattr(self.file_by_uuid, 'did', None)
+                file_by_hash_index = getattr(self.file_by_hash, 'did', None)
+                if ((file_by_uuid_index != nodes[0].node_id) or
+                        (file_by_hash_index != nodes[0].node_id)):
+                    self.record_error(
+                        'Graph ID and index file ID found in index service do not match, '
+                        'which is currently not permitted. Graph ID: {}. '
+                        'Index ID: {}. Index ID found using hash/size: {}.'
+                        .format(nodes[0].node_id, file_by_hash_index, file_by_uuid_index),
+                        type=EntityErrors.NOT_UNIQUE,
+                    )
+                    is_valid = False
+
+        return is_valid
+
+    def get_file_from_index_by_hash(self):
+        """
+        Return the record entity from "signpost" (index client)
+
+        NOTE:
+        - Should only ever be called for data and metadata files.
+        - If there is already a record matching the hash and size for this
+          file, then return none.
+        """
+        document = None
+
+        # ################################################################
+        # SignpostClient is used instead of IndexClient for the GDCAPI.
+        # This means that the client doesn't have access to IndexClient's
+        # methods, causing exceptions to occur.
+        #
+        # Temporary workaround until gdcapi uses indexd
+        # ################################################################
+        if not self._config.get('USE_SIGNPOST', False):
+            # Check if there is an existing record with this hash and size, i.e.
+            # this node already has an index record.
+            params = self._get_file_hashes_and_size()
+            # document: indexclient.Document
+            # if `document` exists, `document.did` is the UUID that is already
+            # registered in indexd for this entity.
+            document = self.transaction.signpost.get_with_params(params)
+
+        return document
+
+    def get_file_from_index_by_uuid(self, uuid):
+        """
+        Return the record entity from "signpost" (index client)
+
+        NOTE:
+        - Should only ever be called for data and metadata files.
+        - If there is already a record matching the hash and size for this
+          file, then return none.
+        """
+        document = None
+
+        if uuid:
+            document = self.transaction.signpost.get(uuid)
+
+        return document
+
+    def get_metadata(self):
+        metadata = {'acls': flask.g.dbgap_accession_numbers}
+        return metadata
+
+    def _get_file_hashes_and_size(self):
+        hashes = self._get_file_hashes()
+        size = self._get_file_size()
+        return {'hashes': hashes, 'size': size}
+
+    def _get_file_hashes(self):
+        return {'md5': self.doc.get('md5sum')}
+
+    def _get_file_size(self):
+        size = self.doc.get('file_size')
+        return size
+
+    def _create_alias(self, **kwargs):
+        return self.transaction.signpost.create_alias(**kwargs)
+
+    def _create_index(self, **kwargs):
+        return self.transaction.signpost.create(**kwargs)

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -93,7 +93,7 @@ class FileUploadEntity(UploadEntity):
                 self.entity_id = doc.did
                 self.file_exists = True
         else:
-            self._check_index_for_file(self.entity_id)
+            self._populate_files_from_index(self.entity_id)
             self._set_node_and_file_ids()
 
         # call to super must happen after setting node and file ids here
@@ -136,7 +136,7 @@ class FileUploadEntity(UploadEntity):
         if self._config.get('USE_SIGNPOST', False):
             pass
         else:
-            self._check_index_for_file(self.entity_id)
+            self._populate_files_from_index(self.entity_id)
             self._is_valid_index_id_for_graph()
 
         return node
@@ -259,7 +259,7 @@ class FileUploadEntity(UploadEntity):
 
         return is_updateable
 
-    def _check_index_for_file(self, uuid=None):
+    def _populate_files_from_index(self, uuid=None):
         """
         Populate information about file existence in index service.
         Will first check provided uuid, then check by hash/size.

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -6,7 +6,6 @@ from collections import Counter
 
 # Validating Entity Existence in dbGaP
 from datamodelutils import validators
-from flask import current_app
 from sqlalchemy.orm.attributes import flag_modified
 
 from sheepdog.auth import dbgap
@@ -19,11 +18,9 @@ from sheepdog.globals import (
     TX_LOG_STATE_FAILED,
     TX_LOG_STATE_SUCCEEDED,
 )
-from sheepdog.transactions.upload.entity import (
-    EntityErrors,
-    UploadEntity,
-)
+from sheepdog.transactions.upload.entity import EntityErrors
 from sheepdog.transactions.transaction_base import TransactionBase
+from sheepdog.transactions.upload.entity_factory import UploadEntityFactory
 
 
 class UploadTransaction(TransactionBase):
@@ -63,7 +60,7 @@ class UploadTransaction(TransactionBase):
             self.db_driver,
             self.logger,
             proxies=self.external_proxies,
-	)
+        )
 
         self._config = kwargs['flask_config']
 
@@ -276,9 +273,9 @@ class UploadTransaction(TransactionBase):
             None
         """
         try:
-            entity = UploadEntity(self, self._config)
-            self.entities.append(entity)
+            entity = UploadEntityFactory.create(self, doc, self._config)
             entity.parse(doc)
+            self.entities.append(entity)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(e)
             self.record_error('Unable to parse entity')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,7 @@ def user_setup():
         users = s.query(usermd.User).all()
         test_user = s.query(usermd.User).filter(
             usermd.User.username == 'test').first()
-        test_user.is_admin =True
+        test_user.is_admin = True
         projects = ['phs000218', 'phs000235', 'phs000178']
         admin = s.query(usermd.User).filter(
             usermd.User.username == 'admin').first()

--- a/tests/submission/test_endpoints.py
+++ b/tests/submission/test_endpoints.py
@@ -24,6 +24,7 @@ BRCA_PATH = '/v0/submission/TCGA/BRCA/'
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 
+
 @contextlib.contextmanager
 def s3_conn():
     mock = mock_s3()

--- a/tests/submission/test_upload.py
+++ b/tests/submission/test_upload.py
@@ -1,0 +1,597 @@
+"""
+Test upload entities (mostly data file handling and communication with
+index service).
+
+Some things to note about data files and the index service:
+- submitter_id/project should be unique per graph node
+- submitter_id/project are used to create an alias in the index service to
+  a data file
+- when sheepdog attempts to find out if a file exists in index service it
+  has TWO methods of determining
+    FIXME At the moment, there is a 1:1 mapping of id's between graph nodes and
+          indexed files. eventually, there'll be a file_id attr in the graph node
+    1) If a file uuid exists in the graph node or is provided in the submission,
+       we can look up that uuid in index service
+    2) The hash/file_size combo should be unique in the index service for each
+       file
+"""
+import json
+import copy
+
+from test_endpoints import put_cgci_blgsp
+
+from utils import assert_positive_response
+from utils import assert_negative_response
+from utils import assert_single_entity_from_response
+
+# Python 2 and 3 compatible
+try:
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+except ImportError:
+    from mock import MagicMock
+    from mock import patch
+
+BLGSP_PATH = '/v0/submission/CGCI/BLGSP/'
+
+# some default values for data file submissions
+DEFAULT_FILE_HASH = '00000000000000000000000000000001'
+DEFAULT_FILE_SIZE = 1
+DEFAULT_URL = 'test/url/test/0'
+DEFAULT_SUBMITTER_ID = '0'
+DEFAULT_UUID = 'bef870b0-1d2a-4873-b0db-14994b2f89bd'
+
+DEFAULT_METADATA_FILE = {
+    'type': 'experimental_metadata',
+    'data_type': 'Experimental Metadata',
+    'file_name': 'test-file',
+    'md5sum': DEFAULT_FILE_HASH,
+    'data_format': 'some_format',
+    'submitter_id': DEFAULT_SUBMITTER_ID,
+    'experiments': {
+        'submitter_id': 'BLGSP-71-06-00019'
+    },
+    'data_category': 'data_file',
+    'file_size': DEFAULT_FILE_SIZE,
+    'state_comment': '',
+    'url': DEFAULT_URL
+}
+
+
+def submit_first_experiment(client, pg_driver, submitter, dictionary_setup):
+    dictionary_setup('s3://test.com')
+    put_cgci_blgsp(client, submitter)
+    headers = submitter(BLGSP_PATH, 'put')
+
+    # first submit experiment
+    data = json.dumps({
+        'type': 'experiment',
+        'submitter_id': 'BLGSP-71-06-00019',
+        'projects': {
+            'id': 'daa208a7-f57a-562c-a04a-7a7c77542c98'
+        }
+    })
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+def submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=DEFAULT_METADATA_FILE):
+    dictionary_setup('s3://test.com')
+    put_cgci_blgsp(client, submitter)
+    headers = submitter(BLGSP_PATH, 'put')
+    data = json.dumps(data)
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    return resp
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_not_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test node and data file creation when neither exist and no ID is provided.
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    get_index_uuid.return_value = None
+    get_index_hash.return_value = None
+
+    resp = submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # index creation
+    assert create_index.call_count == 1
+    args, kwargs = create_index.call_args_list[0]
+    assert 'did' in kwargs
+    did = kwargs['did']
+    assert 'hashes' in kwargs
+    assert kwargs['hashes'].get('md5') == DEFAULT_FILE_HASH
+    assert 'urls' in kwargs
+    assert DEFAULT_URL in kwargs['urls']
+
+    # alias creation
+    assert create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert entity['id'] == did
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_not_indexed_id_provided(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test node and data file creation when neither exist and an ID is provided.
+    That ID should be used for the node and file index creation
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    get_index_uuid.return_value = None
+    get_index_hash.return_value = None
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file['id'] = DEFAULT_UUID
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=file)
+
+    # index creation
+    assert create_index.call_count == 1
+    args, kwargs = create_index.call_args_list[0]
+    assert 'did' in kwargs
+    did = kwargs['did']
+    assert 'hashes' in kwargs
+    assert kwargs['hashes'].get('md5') == DEFAULT_FILE_HASH
+    assert 'urls' in kwargs
+    assert DEFAULT_URL in kwargs['urls']
+
+    # alias creation
+    assert create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert did == DEFAULT_UUID
+    assert entity['id'] == DEFAULT_UUID
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_already_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting when the file is already indexed in the index client and
+    no ID is provided. sheepdog should fall back on the hash/size of the file
+    to find it in indexing service.
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    resp = submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert entity['id'] == document.did
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_already_indexed_id_provided(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting when the file is already indexed in the index client and
+    an id is provided in the submission.
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file['id'] = document.did
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert entity['id'] == document.did
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the same data again but updating the URL field (should
+    get added to the indexed file in index service).
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    document.urls = [DEFAULT_URL]
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url and new url are in the document and patch gets called
+    assert DEFAULT_URL in document.urls
+    assert new_url in document.urls
+    assert document.patch.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'update'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert entity['id'] == document.did
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url_id_provided(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the same data again (with the id provided) and updating the
+    URL field (should get added to the indexed file in index service).
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    document.urls = [DEFAULT_URL]
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    updated_file['id'] = document.did
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url and new url are in the document and patch gets called
+    assert DEFAULT_URL in document.urls
+    assert new_url in document.urls
+    assert document.patch.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'update'
+
+    # make sure uuid in node is the same as the uuid from index
+    # FIXME this is a temporary solution so these tests will probably
+    #       need to change in the future
+    assert entity['id'] == document.did
+
+
+""" ----- TESTS THAT SHOULD RESULT IN SUBMISSION FAILURES ARE BELOW  ----- """
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url_invalid_id(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the same data again (with the WRONG id provided).
+    i.e. ID provided doesn't match the id from the index service for the file
+         found with the hash/size provided
+
+    FIXME: the 1:1 between node id and index/file id is temporary so this
+           test may need to be modified in the future
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    document.urls = [DEFAULT_URL]
+    get_index_hash.return_value = document
+
+    # the uuid provided doesn't have a matching indexed file
+    get_index_uuid.return_value = None
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    updated_file['id'] = DEFAULT_UUID
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url is still there and new url is NOT
+    assert DEFAULT_URL in document.urls
+    assert new_url not in document.urls
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url_id_provided_different_file_not_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the same data again (with the id provided) and updating the
+    URL field.
+
+    HOWEVER the file hash and size in the new data do NOT match the previously
+    submitted data for the given ID. The file hash/size provided does NOT
+    match an already indexed file. e.g. The file is not yet indexed.
+
+    The asssumption is that the user is attempting to UPDATE the index
+    with a new file.
+
+    FIXME At the moment, we do not allow updating like this
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = DEFAULT_UUID
+    document.urls = [DEFAULT_URL]
+    get_index_uuid.return_value = document
+
+    # index yeilds no match given hash/size
+    get_index_hash.return_value = None
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    updated_file['id'] = DEFAULT_UUID
+    updated_file['md5sum'] = DEFAULT_FILE_HASH.replace('0', '2')
+    updated_file['file_size'] = DEFAULT_FILE_SIZE + 1
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url is still there and new url is NOT
+    assert DEFAULT_URL in document.urls
+    assert new_url not in document.urls
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url_different_file_not_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the different data (with NO id provided) and updating the
+    URL field.
+
+    HOWEVER the file hash and size in the new data do NOT match the previously
+    submitted data. The file hash/size provided does NOT
+    match an already indexed file. e.g. The file is not yet indexed.
+
+    The asssumption is that the user is attempting to UPDATE the index
+    with a new file but didn't provide a full id, just the same submitter_id
+    as before.
+
+    Without an ID provided, sheepdog falls back on secondary keys (being
+    the submitter_id/project). There is already a match for that, BUT
+    the provided file hash/size is different than the previously submitted one.
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = DEFAULT_UUID
+    document.urls = [DEFAULT_URL]
+    get_index_uuid.return_value = document
+
+    # index yeilds no match given hash/size
+    get_index_hash.return_value = None
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    updated_file['md5sum'] = DEFAULT_FILE_HASH.replace('0', '2')
+    updated_file['file_size'] = DEFAULT_FILE_SIZE + 1
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url is still there and new url is NOT
+    assert DEFAULT_URL in document.urls
+    assert new_url not in document.urls
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_update_url_id_provided_different_file_already_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup):
+    """
+    Test submitting the same data again (with the id provided) and updating the
+    URL field (should get added to the indexed file in index service).
+
+    HOWEVER the file hash and size in the new data MATCH A DIFFERENT
+    FILE in the index service that does NOT have the id provided.
+
+    The asssumption is that the user is attempting to UPDATE the index
+    with a new file they've already submitted under a different id.
+
+    FIXME At the moment, we do not allow updating like this
+    """
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document_with_id = MagicMock()
+    document_with_id.did = DEFAULT_UUID
+    document_with_id.urls = [DEFAULT_URL]
+
+    different_file_matching_hash_and_size = MagicMock()
+    different_file_matching_hash_and_size.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    different_file_matching_hash_and_size.urls = [DEFAULT_URL]
+
+    get_index_uuid.return_value = document_with_id
+    get_index_hash.return_value = different_file_matching_hash_and_size
+
+    submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # now submit again but change url
+    new_url = 'some/new/url/location/to/add'
+    updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    updated_file['url'] = new_url
+    updated_file['id'] = DEFAULT_UUID
+    updated_file['md5sum'] = DEFAULT_FILE_HASH.replace('0', '2')
+    updated_file['file_size'] = DEFAULT_FILE_SIZE + 1
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=updated_file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # make sure original url is still there and new url is NOT
+    assert DEFAULT_URL in document_with_id.urls
+    assert DEFAULT_URL in different_file_matching_hash_and_size.urls
+    assert new_url not in document_with_id.urls
+    assert new_url not in different_file_matching_hash_and_size.urls
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)

--- a/tests/submission/test_upload.py
+++ b/tests/submission/test_upload.py
@@ -1,19 +1,6 @@
 """
 Test upload entities (mostly data file handling and communication with
 index service).
-
-Some things to note about data files and the index service:
-- submitter_id/project should be unique per graph node
-- submitter_id/project are used to create an alias in the index service to
-  a data file
-- when sheepdog attempts to find out if a file exists in index service it
-  has TWO methods of determining
-    FIXME At the moment, there is a 1:1 mapping of id's between graph nodes and
-          indexed files. eventually, there'll be a file_id attr in the graph node
-    1) If a file uuid exists in the graph node or is provided in the submission,
-       we can look up that uuid in index service
-    2) The hash/file_size combo should be unique in the index service for each
-       file
 """
 import json
 import copy

--- a/tests/submission/test_upload_signpost.py
+++ b/tests/submission/test_upload_signpost.py
@@ -1,0 +1,230 @@
+"""
+BACKWARDS COMPATIBILITY TESTING FOR GDC USE WITH SIGNPOST
+
+Test upload entities (mostly data file handling and communication with
+index service).
+
+Essentially, there are only 2 cases being handled:
+    1) id is provided, don't create file in index since assigning id's are
+       not allowed
+    2) no id is provided, create a new file in the index regardless of whether
+       or not that file already exists in the index
+"""
+import json
+import flask
+import copy
+
+from test_upload import submit_first_experiment
+from test_upload import submit_metadata_file
+
+from utils import assert_positive_response
+from utils import assert_negative_response
+from utils import assert_single_entity_from_response
+
+# Python 2 and 3 compatible
+try:
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+except ImportError:
+    from mock import MagicMock
+    from mock import patch
+
+BLGSP_PATH = '/v0/submission/CGCI/BLGSP/'
+
+# some default values for data file submissions
+DEFAULT_FILE_HASH = '00000000000000000000000000000001'
+DEFAULT_FILE_SIZE = 1
+DEFAULT_URL = 'test/url/test/0'
+DEFAULT_SUBMITTER_ID = '0'
+DEFAULT_UUID = 'bef870b0-1d2a-4873-b0db-14994b2f89bd'
+
+DEFAULT_METADATA_FILE = {
+    'type': 'experimental_metadata',
+    'data_type': 'Experimental Metadata',
+    'file_name': 'test-file',
+    'md5sum': DEFAULT_FILE_HASH,
+    'data_format': 'some_format',
+    'submitter_id': DEFAULT_SUBMITTER_ID,
+    'experiments': {
+        'submitter_id': 'BLGSP-71-06-00019'
+    },
+    'data_category': 'data_file',
+    'file_size': DEFAULT_FILE_SIZE,
+    'state_comment': '',
+    'url': DEFAULT_URL
+}
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_not_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup, monkeypatch):
+    """
+    Test node and data file creation when neither exist and no ID is provided.
+    """
+    monkeypatch.setitem(flask.current_app.config, 'USE_SIGNPOST', True)
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    get_index_uuid.return_value = None
+    get_index_hash.return_value = None
+
+    # signpost create will return a document
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    create_index.return_value = document
+
+    resp = submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # index creation should be called with no args for SIGNPOST
+    assert create_index.call_count == 1
+    args, kwargs = create_index.call_args_list[0]
+    assert not args
+    assert not kwargs
+
+    # no support for aliases
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_not_indexed_id_provided(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup, monkeypatch):
+    """
+    Test node and data file creation when neither exist and an ID is provided.
+
+    NOTE: signpostclient will NOT create add a file to the index service if an ID
+          is provided
+    """
+    monkeypatch.setitem(flask.current_app.config, 'USE_SIGNPOST', True)
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    get_index_uuid.return_value = None
+    get_index_hash.return_value = None
+
+    # signpost create will return a document
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    create_index.return_value = document
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file['id'] = DEFAULT_UUID
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=file)
+
+    # no index creation
+    assert not create_index.called
+
+    # no support for aliases
+    assert not create_alias.called
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_already_indexed(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup, monkeypatch):
+    """
+    Test submitting when the file is already indexed in the index client and
+    no ID is provided. sheepdog should fall back on the hash/size of the file
+    to find it in indexing service.
+
+    NOTE: signpostclient will create another file in the index service regardless
+          of whether or not the file exists. signpostclient does not
+          have capabilities of searching for files based on hash/size
+    """
+    monkeypatch.setitem(flask.current_app.config, 'USE_SIGNPOST', True)
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    # signpostclient cannot find by hash/size
+    get_index_hash.return_value = None
+    get_index_uuid.return_value = None
+
+    # signpost create will return a document
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    create_index.return_value = document
+
+    resp = submit_metadata_file(client, pg_driver, submitter, dictionary_setup)
+
+    # index creation should be called with no args for SIGNPOST
+    assert create_index.call_count == 1
+    args, kwargs = create_index.call_args_list[0]
+    assert not args
+    assert not kwargs
+
+    # no support for aliases
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.entity.UploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_index')
+@patch('sheepdog.transactions.upload.entity.UploadEntity._create_alias')
+def test_data_file_already_indexed_id_provided(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, submitter, dictionary_setup, monkeypatch):
+    """
+    Test submitting when the file is already indexed in the index client and
+    an id is provided in the submission.
+
+    NOTE: signpostclient will NOT create add a file to the index service if an ID
+          is provided
+    """
+    monkeypatch.setitem(flask.current_app.config, 'USE_SIGNPOST', True)
+    submit_first_experiment(client, pg_driver, submitter, dictionary_setup)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    get_index_uuid.return_value = document
+
+    # signpostclient cannot find by hash/size
+    get_index_hash.return_value = None
+
+    # signpost create will return a document
+    create_index.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file['id'] = document.did
+    resp = submit_metadata_file(
+        client, pg_driver, submitter, dictionary_setup, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # no support for aliases
+    assert not create_alias.called
+
+    # response
+    assert_negative_response(resp)
+    assert_single_entity_from_response(resp)


### PR DESCRIPTION
- Addition of allowing "urls" field to submissions to update/populate url field of indexed data file (does not interfere with validation against the dictionary, i.e. the dictionary doesn't need to be updated to include this urls field)
- modify logic behind sheepdog->index service to enforce 1:1 between graph node uuid and index uuid
- allow updating of indexed files (specifically the URLs field)
- refactor upload entity to logically separate file-like and non-file-like entities
- add unit tests for new upload changes
- add minimal unit tests to make surre backwards compatibility (the USE_SIGNPOST flag) is mainted for GDC use
- improve/add errors to identity potential new issues during upload