### PR TITLE
chore(nginx): up worker connection limit

### DIFF
--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -3,7 +3,7 @@ worker_processes auto;
 pid /run/nginx.pid;
 
 events {
-	worker_connections 768;
+	worker_connections 100000;
 	# multi_accept on;
 }
 


### PR DESCRIPTION
applies step 1 in https://hexadix.com/slowloris-dos-attack-mitigation-nginx-web-server/
to mitigate slowloris to handle https://github.com/uc-cdis/cloud-automation/issues/219
@rpowellgit  told me just do step 1