### PR TITLE
fix/duplicate-uuid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-setuptools \
     sudo \
     vim \
-    && python -m pip install --force-reinstall pip \
+    && pip install --upgrade pip \
+    && hash -r pip \
     && pip install --upgrade setuptools \
     && pip install uwsgi \
     && mkdir /var/www/sheepdog \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chown www-data -R /var/www/.cache/Python-Eggs/ \
     && mkdir /run/nginx/
 
+# NOTE: hash -r pip is to fix issues with upgrading to pip 10
+# see https://github.com/pypa/pip/issues/5221#issuecomment-381568428
+
 COPY . /sheepdog
 COPY ./deployment/uwsgi/uwsgi.ini /etc/uwsgi/uwsgi.ini
 COPY ./deployment/nginx/nginx.conf /etc/nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-setuptools \
     sudo \
     vim \
-    && pip install --upgrade pip \
+    && python -m pip install --force-reinstall pip \
     && pip install --upgrade setuptools \
     && pip install uwsgi \
     && mkdir /var/www/sheepdog \

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -22,14 +22,22 @@ from sheepdog.utils import get_suggestion
 
 def lookup_node(psql_driver, label, node_id=None, secondary_keys=None):
     """Return a query for nodes by id and secondary keys."""
-    cls = psqlgraph.Node.get_subclass(label)
-    query = psql_driver.nodes(cls)
+    if label:
+        node_class = psqlgraph.Node.get_subclass(label)
+        query = psql_driver.nodes(node_class)
+    else:
+        query = psql_driver.nodes()
+
     if node_id is None and not secondary_keys:
         return query.filter(sqlalchemy.sql.false())
+
     if node_id is not None:
         query = query.ids(node_id)
-    if all(all(keys) for keys in secondary_keys):
-        query = query.filter(cls._secondary_keys == secondary_keys)
+
+    if label:
+        if all(all(keys) for keys in secondary_keys):
+            query = query.filter(node_class._secondary_keys == secondary_keys)
+
     return query
 
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -418,7 +418,7 @@ class FileUploadEntity(UploadEntity):
         # file exists in index service
         nodes = lookup_node(
             self.transaction.db_driver,
-            self.entity_type,
+            None,  # Don't give it a node type, make sure id if valid across all types
             self.entity_id,
             self.secondary_keys
         ).all()
@@ -433,6 +433,17 @@ class FileUploadEntity(UploadEntity):
                         'which is currently not permitted. Graph ID: {}. '
                         'Index ID: {}. Index ID found using hash/size: {}.'
                         .format(nodes[0].node_id, file_by_hash_index, file_by_uuid_index),
+                        type=EntityErrors.NOT_UNIQUE,
+                    )
+                    is_valid = False
+
+                if self.entity_type != nodes[0].label:
+                    self.record_error(
+                        'Graph Node with ID {} and File with ID {} exist but '
+                        'Graph Node has a different node type: {}. Type provided: {}'
+                        .format(
+                            nodes[0].node_id, file_by_hash_index,
+                            nodes[0].label, self.entity_type),
                         type=EntityErrors.NOT_UNIQUE,
                     )
                     is_valid = False

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -323,40 +323,29 @@ class FileUploadEntity(UploadEntity):
         information provided and whether or not the file exists in the
         index service.
         """
-        current_app.logger.info(
-            'Before setting uuids\nfile_exists:{}, entity_id:{}, file_index:{}'
-            .format(self.file_exists, self.entity_id, self.file_index))
-
         if not self.file_exists:
             if self.entity_id:
-                current_app.logger.info('use entity_id for file creation')
+                # use entity_id for file creation
                 self.file_index = self.entity_id
             else:
-                current_app.logger.info('use same id for both node entity id and file index')
+                # use same id for both node entity id and file index
                 self.entity_id = str(uuid.uuid4())
                 self.file_index = self.entity_id
         else:
             if self.entity_id:
-                current_app.logger.info(
-                    'check to make sure that when file exists '
-                    'and an id is provided that they are the same')
+                # check to make sure that when file exists
+                # and an id is provided that they are the same
                 # NOTE: record errors are populated in check below
                 self._is_valid_index_for_file()
             else:
-                current_app.logger.info(
-                    'the file exists in indexd and '
-                    'no node id is provided, so attempt to use indexed id')
+                # the file exists in indexd and
+                # no node id is provided, so attempt to use indexed id
                 file_by_hash_index = getattr(self.file_by_hash, 'did', None)
 
                 # ensure that the index we found matches the graph (this will
                 # populate record errors if there are any issues)
                 if self._is_valid_index_id_for_graph():
                     self.entity_id = file_by_hash_index
-
-        current_app.logger.info(
-            'AFTER setting uuids\nfile_exists:{}, entity_id:{}, file_index:{}'
-            .format(self.file_exists, self.entity_id, self.file_index)
-        )
 
     def _is_valid_index_for_file(self):
         """

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -10,6 +10,8 @@ from sheepdog.transactions.entity_base import EntityErrors
 from sheepdog.transactions.upload.entity import UploadEntity
 from sheepdog.transactions.upload.entity import lookup_node
 
+from flask import current_app
+
 
 class NonFileUploadEntity(UploadEntity):
     """
@@ -321,27 +323,27 @@ class FileUploadEntity(UploadEntity):
         information provided and whether or not the file exists in the
         index service.
         """
-        self.logger.info(
+        current_app.logger.info(
             'Before setting uuids\nfile_exists:{}, entity_id:{}, file_index:{}'
             .format(self.file_exists, self.entity_id, self.file_index))
 
         if not self.file_exists:
             if self.entity_id:
-                self.logger.info('use entity_id for file creation')
+                current_app.logger.info('use entity_id for file creation')
                 self.file_index = self.entity_id
             else:
-                self.logger.info('use same id for both node entity id and file index')
+                current_app.logger.info('use same id for both node entity id and file index')
                 self.entity_id = str(uuid.uuid4())
                 self.file_index = self.entity_id
         else:
             if self.entity_id:
-                self.logger.info(
+                current_app.logger.info(
                     'check to make sure that when file exists '
                     'and an id is provided that they are the same')
                 # NOTE: record errors are populated in check below
                 self._is_valid_index_for_file()
             else:
-                self.logger.info(
+                current_app.logger.info(
                     'the file exists in indexd and '
                     'no node id is provided, so attempt to use indexed id')
                 file_by_hash_index = getattr(self.file_by_hash, 'did', None)
@@ -351,7 +353,7 @@ class FileUploadEntity(UploadEntity):
                 if self._is_valid_index_id_for_graph():
                     self.entity_id = file_by_hash_index
 
-        self.logger.info(
+        current_app.logger.info(
             'AFTER setting uuids\nfile_exists:{}, entity_id:{}, file_index:{}'
             .format(self.file_exists, self.entity_id, self.file_index)
         )

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -10,8 +10,6 @@ from sheepdog.transactions.entity_base import EntityErrors
 from sheepdog.transactions.upload.entity import UploadEntity
 from sheepdog.transactions.upload.entity import lookup_node
 
-from flask import current_app
-
 
 class NonFileUploadEntity(UploadEntity):
     """

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -314,9 +314,7 @@ def test_resubmit_data_file_already_indexed_different_type(
 
     resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
 
-    """
-    Now submit again but a different type and new submitter id
-    """
+    # Now submit again but a different type and new submitter id
     new_file = copy.deepcopy(DIFFERENT_DATA_FILE)
     new_file['submitter_id'] = 'different_submitter_id'
     resp = submit_submitted_methylation(

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -44,20 +44,107 @@ DEFAULT_METADATA_FILE = {
     'urls': DEFAULT_URL
 }
 
+EXPERIMENT_ID = 'f4f46d10-df41-4b3e-82df-aadcc808b34b'
+EXPERIMENT_SUBMITTER_ID = 'BLGSP-71-06-00019'
+CASE_ID = '57b20788-fba4-4112-9865-f464bd58561b'
+CASE_SUBMITTER_ID = 'case-0'
+SAMPLE_ID = '7389a0b5-31ef-4c39-b661-a755d20b0d60'
+SAMPLE_SUBMITTER_ID = 'sample-0'
+ALIQUOT_ID = '30a01bce-2a1b-4fdc-89f2-6d326f877719'
+ALIQUOT_SUBMITTER_ID = 'aliquot-0'
+
+DIFFERENT_DATA_FILE = {
+    'data_type': 'Methylation Intensity Values',
+    'assay_instrument_model': 'Illumina Infinium HumanMethylation450K',
+    'file_name': 'TEST',
+    'submitter_id': DEFAULT_SUBMITTER_ID,
+    'aliquots': [
+      {
+        'id': ALIQUOT_ID,
+        'submitter_id': ALIQUOT_SUBMITTER_ID
+      }
+    ],
+    'file_size': DEFAULT_FILE_SIZE,
+    'md5sum': DEFAULT_FILE_HASH,
+    'data_format': 'IDAT',
+    'data_category': 'Methylation Data',
+    'type': 'submitted_methylation'
+}
+
 
 def submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp):
     put_cgci_blgsp(client, admin)
 
     # first submit experiment
     data = json.dumps({
+        'id': EXPERIMENT_ID,
         'type': 'experiment',
-        'submitter_id': 'BLGSP-71-06-00019',
+        'submitter_id': EXPERIMENT_SUBMITTER_ID,
         'projects': {
             'id': 'daa208a7-f57a-562c-a04a-7a7c77542c98'
         }
     })
     resp = client.put(BLGSP_PATH, headers=submitter, data=data)
     assert resp.status_code == 200, resp.data
+
+
+def submit_case(client, pg_driver, admin, submitter, cgci_blgsp):
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    # first submit experiment
+    data = json.dumps({
+        'id': CASE_ID,
+        'disease_type': 'TEST',
+        'submitter_id': CASE_SUBMITTER_ID,
+        'experiments': {
+            'submitter_id': EXPERIMENT_SUBMITTER_ID
+        },
+        'primary_site': 'TEST',
+        'type': 'case'
+    })
+    resp = client.put(BLGSP_PATH, headers=submitter, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+def submit_sample(client, pg_driver, admin, submitter, cgci_blgsp):
+    submit_case(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    # first submit experiment
+    data = json.dumps({
+        'id': SAMPLE_ID,
+        'submitter_id': SAMPLE_SUBMITTER_ID,
+        'cases': {
+            'submitter_id': CASE_SUBMITTER_ID
+        },
+        'type': 'sample',
+    })
+    resp = client.put(BLGSP_PATH, headers=submitter, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+def submit_aliquot(client, pg_driver, admin, submitter, cgci_blgsp):
+    submit_sample(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    # first submit experiment
+    data = json.dumps({
+        'id': ALIQUOT_ID,
+        'submitter_id': ALIQUOT_SUBMITTER_ID,
+        'samples': {
+            'submitter_id': SAMPLE_SUBMITTER_ID
+        },
+        'type': 'aliquot',
+    })
+    resp = client.put(BLGSP_PATH, headers=submitter, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+def submit_submitted_methylation(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=None):
+    submit_sample(client, pg_driver, admin, submitter, cgci_blgsp)
+    data = data or DIFFERENT_DATA_FILE
+    data = json.dumps(data)
+    resp = client.put(BLGSP_PATH, headers=submitter, data=data)
+    return resp
 
 
 def submit_metadata_file(
@@ -198,6 +285,44 @@ def test_data_file_already_indexed(
     # FIXME this is a temporary solution so these tests will probably
     #       need to change in the future
     assert entity['id'] == document.did
+
+
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
+def test_resubmit_data_file_already_indexed_different_type(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, admin, submitter, cgci_blgsp):
+    """
+
+    """
+    submit_aliquot(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    document = MagicMock()
+    document.did = '14fd1746-61bb-401a-96d2-342cfaf70000'
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    """
+    Now submit again but a different type and new submitter id
+    """
+    new_file = copy.deepcopy(DIFFERENT_DATA_FILE)
+    new_file['submitter_id'] = 'different_submitter_id'
+    resp = submit_submitted_methylation(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=new_file)
+
+    assert_negative_response(resp)
 
 
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')


### PR DESCRIPTION
- Handle issue where a graph node gets created with a UUID that already exists in the graph under a different node type
- When determining if a UUID is valid for the graph:
    - if uuid already exists, make sure it's the same type as the submission (in which case we'd be updating)
    - if uuid already exists and the submission is a different type, we should NOT allow creation
- added regression test
- Additionally, fix an issue with the image build failling because of pip 10 being released 

pip 10 fix: https://github.com/pypa/pip/issues/5221#issuecomment-381568428

TODO fix internal error when submitting same thing but changing submitter id