### PR TITLE
fix(delete): allow deletion if state is not set

### DIFF
--- a/sheepdog/transactions/deletion/entity.py
+++ b/sheepdog/transactions/deletion/entity.py
@@ -6,7 +6,7 @@ from sheepdog.transactions.entity_base import EntityBase, EntityErrors
 from sheepdog.transactions.transaction_base import MissingNode
 
 
-ALLOWED_DELETION_FILE_STATES = [submitted_state()]
+ALLOWED_DELETION_FILE_STATES = [submitted_state(), None]
 
 
 class DeletionEntity(EntityBase):


### PR DESCRIPTION
if the data file hasn't been touched after the node is uploaded(if it's touched with any data upload endpoint, it will be moved to various states), the file_state is in None state, it should allow deletion.