### PR TITLE
fix(project-create): no restriction on project create

### DIFF
--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -123,8 +123,8 @@ def create_project(program):
                 "primary_site": "Lymph Nodes",
                 "dbgap_accession_number": "phs000527",
                 "state": "active",
-                "dbgap_bypass_prefix": "test-",
-                "dbgap_bypass_range": 10
+                "bypass_case_prefix": "test-",
+                "bypass_case_range": 10
             }
     """
 

--- a/sheepdog/transactions/transaction_base.py
+++ b/sheepdog/transactions/transaction_base.py
@@ -44,9 +44,7 @@ class TransactionBase(object):
     """
 
     REQUIRED_PROJECT_STATES = []
-    required_project_flags  = {
-        'submission_enabled': [True],
-    }
+    required_project_flags = dict()
 
     def __init__(self, program, project, **kwargs):
         """


### PR DESCRIPTION
- project create was looking at TransactionBase to do the create, which
calls `assert_project_state`. It's best to keep the project states empty
by default. At least until the project is made.

- project create comment updates