### PR TITLE
[fix][API-533]: fix sheepdog.utils.get_indexd_state and released node states

### DIFF
--- a/sheepdog/globals.py
+++ b/sheepdog/globals.py
@@ -221,3 +221,9 @@ UPDATABLE_FILE_STATES = [
     'validating',
     'error',
 ]
+
+# Below is the list of node states that are treated as "released"
+RELEASED_NODE_STATES = [
+    'released',
+    'live',
+]

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -21,7 +21,7 @@ from sheepdog.transactions.upload.entity import (
 )
 from sheepdog.globals import (
     DATA_FILE_CATEGORIES, PRIMARY_URL_TYPE, POSSIBLE_OPEN_FILE_NODES,
-    UPDATABLE_FILE_STATES
+    UPDATABLE_FILE_STATES, RELEASED_NODE_STATES
 )
 from sheepdog.errors import UserError
 from sqlalchemy.orm.exc import NoResultFound
@@ -170,7 +170,7 @@ class FileUploadEntity(UploadEntity):
         # entity_id is set to the node_id here
         node = super(FileUploadEntity, self).get_node_merge()
 
-        if node.state == 'released':
+        if node.state in RELEASED_NODE_STATES:
             node = self.get_node_recreate()
 
         self._populate_file_exist_in_index()

--- a/sheepdog/utils/__init__.py
+++ b/sheepdog/utils/__init__.py
@@ -347,7 +347,7 @@ def get_indexd_state(did, url, indexd_client, return_not_found=False):
 
     # If url is provided return url's 'state' or None
     if url is not None:
-        return indexd_doc.get(url, {}).get('state')
+        return indexd_doc.urls_metadata.get(url, {}).get('state')
 
     # If url is None, lookup primary url
     for url, url_meta in indexd_doc.urls_metadata.items():

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -663,8 +663,10 @@ def test_update_multiple_one_fails(
         'CREATE_REPLACEABLE': True
     }
 )
+@pytest.mark.parametrize('released_state', ['released', 'live'])
 def test_update_released_non_file_node(
-        client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client):
+        client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client,
+        released_state):
     resp_json, sur_entity = data_file_creation(
         client_toggled, submitter,
         sur_filename='submitted_unaligned_reads.json')
@@ -673,10 +675,10 @@ def test_update_released_non_file_node(
     with pg_driver.session_scope():
         for entity in resp_json['entities']:
             node = pg_driver.nodes().get(entity['id'])
-            node.state = 'released'
+            node.state = released_state
 
         node = pg_driver.nodes().get(sur_entity['id'])
-        node.state = 'released'
+        node.state = released_state
 
     # Load original case.json to validate the values
     case_json = read_json_data(
@@ -720,8 +722,10 @@ def test_update_released_non_file_node(
         'CREATE_REPLACEABLE': True
     }
 )
+@pytest.mark.parametrize('released_state', ['released', 'live'])
 def test_links_inherited_for_file_nodes(
-        client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client):
+        client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client,
+        released_state):
     resp_json, sar_entity = data_file_creation(
         client_toggled, submitter,
         sur_filename='submitted_aligned_reads.json'
@@ -746,9 +750,9 @@ def test_links_inherited_for_file_nodes(
     # Release all of the nodes
     with pg_driver.session_scope():
         for entity in resp_json['entities'] + resp_2.json['entities']:
-            pg_driver.nodes().get(entity['id']).state = 'released'
+            pg_driver.nodes().get(entity['id']).state = released_state
 
-        pg_driver.nodes().get(sar_entity['id']).state = 'released'
+        pg_driver.nodes().get(sar_entity['id']).state = released_state
 
     # Save children edges for Submitted Aligned Reads file node
     with pg_driver.session_scope():

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -22,7 +22,7 @@ except ImportError:
     from mock import patch
 
 from gdcdatamodel.models import SubmittedAlignedReads, Case
-from sheepdog.globals import UPDATABLE_FILE_STATES
+from sheepdog.globals import UPDATABLE_FILE_STATES, RELEASED_NODE_STATES
 from sheepdog.transactions.upload.sub_entities import FileUploadEntity
 from sheepdog.test_settings import SUBMISSION
 from sheepdog.utils import (
@@ -663,7 +663,7 @@ def test_update_multiple_one_fails(
         'CREATE_REPLACEABLE': True
     }
 )
-@pytest.mark.parametrize('released_state', ['released', 'live'])
+@pytest.mark.parametrize('released_state', RELEASED_NODE_STATES)
 def test_update_released_non_file_node(
         client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client,
         released_state):
@@ -722,7 +722,7 @@ def test_update_released_non_file_node(
         'CREATE_REPLACEABLE': True
     }
 )
-@pytest.mark.parametrize('released_state', ['released', 'live'])
+@pytest.mark.parametrize('released_state', RELEASED_NODE_STATES)
 def test_links_inherited_for_file_nodes(
         client_toggled, pg_driver, submitter, cgci_blgsp, indexd_client,
         released_state):


### PR DESCRIPTION
This PR addresses the following:
* `sheepdog.utils.get_indexd_state` checks the state of a primary url type defined in `sheepdog.globals.PRIMARY_URL_TYPE`
* Add `sheepdog.globals.RELEASED_NODE_STATES` to cover possible node states that are treated as "released"
* Update unit tests to cover different "released" states.