### PR TITLE
PXD-1961 fix(db_migrate): exit the program when sheepdog fail to migrate the db

### DIFF
--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -86,7 +86,8 @@ def migrate_database(app):
         postgres_admin.create_graph_tables(app.db, timeout=1)
     except Exception:
         if not postgres_admin.check_version(app.db):
-            app.logger.exception("Fail to migrate database, continuing anyway")
+            app.logger.exception("ERROR: Fail to migrate database")
+            sys.exit(1)
         # if the version is already up to date, that means there is
         # another migration wins, so silently exit
         return

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -88,9 +88,11 @@ def migrate_database(app):
         if not postgres_admin.check_version(app.db):
             app.logger.exception("ERROR: Fail to migrate database")
             sys.exit(1)
-        # if the version is already up to date, that means there is
-        # another migration wins, so silently exit
-        return
+        else:
+            # if the version is already up to date, that means there is
+            # another migration wins, so silently exit
+            app.logger.exception("The database version matches up. No need to do migration")
+            return
     # hardcoded read role
     read_role = 'peregrine'
     # check if such role exists


### PR DESCRIPTION


Sheepdog continues executing when a new dictionary fails to deploy.

We would prefer if it bombed out, so we get an obvious failure rather than debug unexpected behavior later.  For example - the following error was only revealed when the ETL process failed, and Thanh manually determined that a database table was not in sync with the dictionary, then re-roll everything to see if the migration hadn't run, and finally checked sheepdog logs:

```
ERROR:sheepdog.api:Fail to migrate database, continuing anyway
Traceback (most recent call last)
File "/sheepdog/sheepdog/api.py", line 86, in migrate_database
postgres_admin.create_graph_tables(app.db, timeout=1)
File "/sheepdog/src/datamodelutils/datamodelutils/postgres_admin.py", line 195, in create_graph_tables
...

IdentifierError: Identifier `node_impulsivecompulsivedisordersquestionnaire_sysan_props_idx` exceeds maximum length of 63 characters

```
