### PR TITLE
PXD-1960 fix(message): fix error message

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -535,7 +535,10 @@ class FileUploadEntity(UploadEntity):
                 try:
                     document = self.transaction.signpost.get_with_params(params)
                 except requests.HTTPError as e:
-                    raise UserError(code=e.response.status_code, message=e.message)
+                    raise UserError(
+                        code=e.response.status_code,
+                        message="Fail to register the data node in indexd. Detail {}".format(e.message)
+                    )
 
         return document
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -3,8 +3,9 @@ Subclasses for UploadEntity that handle different types of
 uploaded entites.
 """
 import uuid
+import requests
 
-from sheepdog.errors import NoIndexForFileError
+from sheepdog.errors import NoIndexForFileError, UserError
 
 from sheepdog import utils
 from sheepdog.transactions.entity_base import EntityErrors
@@ -531,7 +532,10 @@ class FileUploadEntity(UploadEntity):
             # if `document` exists, `document.did` is the UUID that is already
             # registered in indexd for this entity.
             if params:
-                document = self.transaction.signpost.get_with_params(params)
+                try:
+                    document = self.transaction.signpost.get_with_params(params)
+                except requests.HTTPError as e:
+                    raise UserError(code=e.response.status_code, message=e.message)
 
         return document
 

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -109,6 +109,7 @@ class UploadTransaction(TransactionBase):
             # mutated.
             flag_modified(tx_log, 'canonical_json')
 
+        self.json_validator.record_errors(self.entities)
         self.instantiate()
         self.pre_validate()
 
@@ -145,7 +146,6 @@ class UploadTransaction(TransactionBase):
                 )
             checked.add(secondary_keys)
 
-        self.json_validator.record_errors(self.entities)
         self.specify_errors()
 
     def post_validate(self):


### PR DESCRIPTION


See following error:

 

Traceback (most recent call last):
{{ File "/sheepdog/sheepdog/transactions/upload/_init_.py", line 38, in single_transaction_worker}}
{{ transaction.parse_doc(*doc_args)}}
{{ File "/sheepdog/sheepdog/transactions/upload/transaction.py", line 81, in parse_doc}}
{{ self.parse_entities(data)}}
{{ File "/sheepdog/sheepdog/transactions/upload/transaction.py", line 112, in parse_entities}}
{{ self.instantiate()}}
{{ File "/sheepdog/sheepdog/transactions/upload/transaction.py", line 163, in instantiate}}
{{ entity.instantiate()}}
{{ File "/sheepdog/sheepdog/transactions/upload/entity.py", line 149, in instantiate}}
{{ self.node = self.get_node_merge()}}
{{ File "/sheepdog/sheepdog/transactions/upload/sub_entities.py", line 180, in get_node_merge}}
{{ node = super(FileUploadEntity, self).get_node_merge()}}
{{ File "/sheepdog/sheepdog/transactions/upload/entity.py", line 323, in get_node_merge}}
{{ return self.get_node_create()}}
{{ File "/sheepdog/sheepdog/transactions/upload/sub_entities.py", line 158, in get_node_create}}
{{ self._populate_files_from_index()}}
{{ File "/sheepdog/sheepdog/transactions/upload/sub_entities.py", line 377, in _populate_files_from_index}}
{{ self.file_by_hash = self.get_file_from_index_by_hash()}}
{{ File "/sheepdog/sheepdog/transactions/upload/sub_entities.py", line 534, in get_file_from_index_by_hash}}
{{ document = self.transaction.signpost.get_with_params(params)}}
{{ File "/sheepdog/src/indexclient/indexclient/client.py", line 118, in get_with_params}}
{{ raise e}}
HTTPError: 400 Client Error: size must be an integer for url: http://indexd-service/index/?limit=1&hash=md5%3A1E%2B31&size=11.7

Comments
Ascending order - Click to sort in descending order
Permalink
zflamig Zachary Flamig added a comment - 26/Sep/18 1:10 PM

When submitting a file size that isn't an integer (say a float like 11.7) this will generate an internal server error. We should output a better error message instead.

This occurred on NIAID with the imaging_file node.
