### PR TITLE
Feat/update acl

### DIFF
--- a/openapi/swagger.yml
+++ b/openapi/swagger.yml
@@ -303,9 +303,9 @@ paths:
       tags:
       - project
     post:
-      description: Create or update GDC entities. Using the :http:method:`post` on
-        a project's endpoint will create any valid entities specified in the request
-        body.
+      description: Create or update any valid entities specified in the request body.
+        To associate an entity with an existing, already indexed data file, specify
+        the `object_id` in the body of the entity.
       parameters:
       - description: The project to which the submitter belongs and in which the entities
           will be created. The `project_id` is the human-readable code, e.g. BRCA.
@@ -335,9 +335,9 @@ paths:
       tags:
       - entity
     put:
-      description: Create or update GDC entities. Using the :http:method:`post` on
-        a project's endpoint will create any valid entities specified in the request
-        body.
+      description: Create or update any valid entities specified in the request body.
+        To associate an entity with an existing, already indexed data file, specify
+        the `object_id` in the body of the entity.
       parameters:
       - description: The project to which the submitter belongs and in which the entities
           will be created. The `project_id` is the human-readable code, e.g. BRCA.
@@ -427,9 +427,9 @@ paths:
       - dictionary
   /<program>/<project>/_dry_run:
     post:
-      description: Create or update GDC entities. Using the :http:method:`post` on
-        a project's endpoint will create any valid entities specified in the request
-        body.
+      description: Create or update any valid entities specified in the request body.
+        To associate an entity with an existing, already indexed data file, specify
+        the `object_id` in the body of the entity.
       parameters:
       - description: The project to which the submitter belongs and in which the entities
           will be created. The `project_id` is the human-readable code, e.g. BRCA.
@@ -459,9 +459,9 @@ paths:
       tags:
       - dry run
     put:
-      description: Create or update GDC entities. Using the :http:method:`post` on
-        a project's endpoint will create any valid entities specified in the request
-        body.
+      description: Create or update any valid entities specified in the request body.
+        To associate an entity with an existing, already indexed data file, specify
+        the `object_id` in the body of the entity.
       parameters:
       - description: The project to which the submitter belongs and in which the entities
           will be created. The `project_id` is the human-readable code, e.g. BRCA.

--- a/run.py
+++ b/run.py
@@ -11,7 +11,7 @@ from gdcdatamodel import models as md
 from psqlgraph import PolyNode as Node
 
 from sheepdog.api import run_for_development
-from sheepdog.auth import roles as all_roles
+from sheepdog.auth import ROLES as all_roles
 
 
 requests.packages.urllib3.disable_warnings()

--- a/sheepdog/auth/__init__.py
+++ b/sheepdog/auth/__init__.py
@@ -15,6 +15,7 @@ import flask
 import authutils
 from authutils import ROLES, dbgap
 from authutils.user import AuthError, current_user, set_global_user
+from authutils.token.validate import current_token
 from cdiserrors import AuthZError
 
 from sheepdog import models

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -56,10 +56,9 @@ def create_viewer(method, bulk=False, dry_run=False):
     @auth.authorize_for_project(*auth_roles)
     def create_entities(program, project):
         """
-        Create or update GDC entities.
+        Create or update any valid entities specified in the request body.
 
-        Using the :http:method:`post` on a project's endpoint will create any
-        valid entities specified in the request body.
+        To associate an entity with an existing, already indexed data file, specify the `object_id` in the body of the entity.
 
         Summary:
             Create entities

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -406,9 +406,7 @@ class FileUploadEntity(UploadEntity):
                 self.entity_id = str(uuid.uuid4())
 
             if self.file_exists:
-                if self.object_id:
-                    pass # data upload flow (handled in get_node_create)
-                else:
+                if not self.object_id:
                     self.object_id = getattr(self.file_by_hash, 'did', None)
             else:
                 self.file_index = self.object_id

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -541,14 +541,18 @@ class FileUploadEntity(UploadEntity):
 
         else:
             # check that the provided hash/size match those of the file in indexd
-            # TODO: compare hashes
-            if (self._get_file_hashes() != self.file_by_uuid.hashes or self._get_file_size() != self.file_by_uuid.size):
-                error_message = 'Provided hash ({}) and size ({}) do not match those of indexed file for id {} (hash {}, size {}).'.format(
+            # submitted hashes have to be a subset of the indexd ones
+            hashes_match = all(
+                item in self.file_by_uuid.hashes.items()
+                for item in self._get_file_hashes().items()
+            )
+            sizes_match = self._get_file_size() == self.file_by_uuid.size
+
+            if not (hashes_match and sizes_match):
+                error_message = 'Provided hash ({}) and size ({}) do not match those of indexed file for id {}.'.format(
                     self._get_file_hashes(),
                     self._get_file_size(),
-                    entity_id,
-                    self.file_by_uuid.hashes,
-                    self.file_by_uuid.size
+                    entity_id
                 )
                 self.record_error(
                     error_message,

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -524,6 +524,10 @@ class FileUploadEntity(UploadEntity):
         Should only be called when the file already exists in indexd and the object_id is provided.
         """
         if not self.use_object_id(self.entity_type) or not self.object_id or not self.file_exists:
+            self.record_error(
+                'The object_id of an indexed file must be provided.',
+                type=EntityErrors.INVALID_VALUE
+            )
             return False
 
         is_valid = True

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -617,7 +617,7 @@ class FileUploadEntity(UploadEntity):
 
             # update acl and uploader fields in indexd
             try:
-                return self.transaction.signpost._put(
+                self.transaction.signpost._put(
                     url,
                     headers={'content-type': 'application/json'},
                     data=data,

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -400,7 +400,6 @@ class FileUploadEntity(UploadEntity):
                 if self.object_id:
                     # file is already indexed and object_id is provided: data upload flow
                     self._is_valid_hash_size_for_file()
-                    # self._is_valid_index_for_file()
                 else:
                     self.object_id = getattr(self.file_by_hash, 'did', None)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,11 @@ from sheepdog.test_settings import JWT_KEYPAIR_FILES
 from tests import utils
 
 
+SUBMITTER_USERNAME = 'submitter'
+ADMIN_USERNAME = 'admin'
+MEMBER_USERNAME = 'member'
+
+
 @pytest.fixture(scope='session')
 def iss():
     """
@@ -69,18 +74,23 @@ def create_user_header(encoded_jwt):
 def submitter(create_user_header):
     project_ids = ['phs000218', 'phs000235', 'phs000178']
     project_access = {project: ROLES.values() for project in project_ids}
-    return create_user_header('submitter', project_access)
+    return create_user_header(SUBMITTER_USERNAME, project_access)
+
+
+@pytest.fixture()
+def submitter_name():
+    return SUBMITTER_USERNAME
 
 
 @pytest.fixture()
 def admin(create_user_header):
     project_ids = ['phs000218', 'phs000235', 'phs000178']
     project_access = {project: ROLES.values() for project in project_ids}
-    return create_user_header('admin', project_access, is_admin=True)
+    return create_user_header(ADMIN_USERNAME, project_access, is_admin=True)
 
 
 @pytest.fixture()
 def member(create_user_header):
     project_ids = ['phs000218', 'phs000235', 'phs000178']
     project_access = {project: ['_member'] for project in project_ids}
-    return create_user_header('member', project_access)
+    return create_user_header(MEMBER_USERNAME, project_access)

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -423,8 +423,7 @@ def test_data_file_update_url_id_provided(
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._update_acl_uploader_for_file')
 def test_data_file_already_indexed_object_id_provided_hash_match(
-        update_acl_uploader_indexd, create_alias, create_index, get_index_uuid, get_index_hash,
-        client, pg_driver, admin, submitter, submitter_name, cgci_blgsp):
+        update_acl_uploader_indexd, create_alias, create_index, get_index_uuid, get_index_hash, client, pg_driver, admin, submitter, submitter_name, cgci_blgsp):
     """
     Test submitting when the file is already indexed in the index client,
     an id is provided in the submission, and the size and hash match those
@@ -458,12 +457,6 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
             return None
     get_index_uuid.side_effect = get_index_by_uuid
 
-    # mock the update of acl and uploader fields in indexd
-    def _update_acl_uploader_indexd():
-        document.acl = ['read', 'write']
-        document.uploader = None
-    update_acl_uploader_indexd.side_effect = _update_acl_uploader_indexd
-
     resp = submit_metadata_file(
         client, pg_driver, admin, submitter, cgci_blgsp, data=file)
 
@@ -484,8 +477,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     assert data[0]['object_id'] == file['object_id']
 
     # check that the acl and uploader fields have been updated in indexd
-    assert document.acl
-    assert document.uploader is None
+    assert update_acl_uploader_indexd.called
 
 
 """ ----- TESTS THAT SHOULD RESULT IN SUBMISSION FAILURES ARE BELOW  ----- """

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -702,7 +702,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     document = MagicMock()
     document.did = file['object_id']
     document.size = file['file_size']
-    document.hashes = { 'md5': file['md5sum'] }
+    document.hashes = { 'md5': file['md5sum'], 'other': 'abc123' }
     get_index_uuid.return_value = document
     get_index_hash.return_value = document
 

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -484,8 +484,8 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     assert data[0]['object_id'] == file['object_id']
 
     # check that the acl and uploader fields have been updated in indexd
-    assert document.acl != []
-    assert document.uploader == None
+    assert document.acl
+    assert document.uploader is None
 
 
 """ ----- TESTS THAT SHOULD RESULT IN SUBMISSION FAILURES ARE BELOW  ----- """
@@ -802,7 +802,7 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     entity = assert_single_entity_from_response(resp)
 
     # check that the acl and uploader fields have NOT been updated in indexd
-    assert document.acl == []
+    assert not document.acl
     assert document.uploader == DEFAULT_SUBMITTER_ID
 
 
@@ -859,5 +859,5 @@ def test_data_file_already_indexed_object_id_provided_no_hash(
     entity = assert_single_entity_from_response(resp)
 
     # check that the acl and uploader fields have NOT been updated in indexd
-    assert document.acl == []
+    assert not document.acl
     assert document.uploader == DEFAULT_SUBMITTER_ID

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -417,6 +417,77 @@ def test_data_file_update_url_id_provided(
     assert entity['action'] == 'update'
 
 
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._update_acl_uploader_for_file')
+def test_data_file_already_indexed_object_id_provided_hash_match(
+        update_acl_uploader_indexd, create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, admin, submitter, submitter_name, cgci_blgsp):
+    """
+    Test submitting when the file is already indexed in the index client,
+    an id is provided in the submission, and the size and hash match those
+    of the indexed file. The empty acl means the file was just uploaded.
+
+    The submission should succeed but no new index should be created. The acl
+    and uploader field should have been updated as part of the data upload
+    flow.
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    # provide the object_id of an existing indexed file
+    file['object_id'] = '14fd1746-61bb-401a-96d2-342cfaf70000'
+
+    document = MagicMock()
+    document.did = file['object_id']
+    document.size = file['file_size']
+    document.hashes = { 'md5': file['md5sum'], 'other': 'abc123' }
+    document.acl = []
+    document.uploader = submitter_name
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    # mock the update of acl and uploader fields in indexd
+    def _update_acl_uploader_indexd():
+        document.acl = ['read', 'write']
+        document.uploader = None
+    update_acl_uploader_indexd.side_effect = _update_acl_uploader_indexd
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+    path = '/v0/submission/CGCI/BLGSP/export/?format=json&ids={nid}'.format(nid=entity['id'])
+    r = client.get(path, headers=submitter)
+
+    data = r.json
+    assert len(data) == 1
+    assert data[0]['object_id'] == file['object_id']
+
+    # check that the acl and uploader fields have been updated in indexd
+    assert document.acl != []
+    assert document.uploader == None
+
+
 """ ----- TESTS THAT SHOULD RESULT IN SUBMISSION FAILURES ARE BELOW  ----- """
 
 
@@ -677,71 +748,6 @@ def test_create_file_no_required_index(create_alias, create_index, get_index_uui
 
     data = r.json
     assert len(data) == 1
-
-
-@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
-@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
-@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
-@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
-def test_data_file_already_indexed_object_id_provided_hash_match(
-        create_alias, create_index, get_index_uuid, get_index_hash,
-        client, pg_driver, admin, submitter, cgci_blgsp):
-    """
-    Test submitting when the file is already indexed in the index client,
-    an id is provided in the submission, and the size and hash match those
-    of the indexed file. The empty acl means the file was just uploaded.
-
-    The submission should succeed but no new index should be created. The acl
-    and uploader field should have been updated as part of the data upload
-    flow.
-    """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
-
-    file = copy.deepcopy(DEFAULT_METADATA_FILE)
-    # provide the object_id of an existing indexed file
-    file['object_id'] = '14fd1746-61bb-401a-96d2-342cfaf70000'
-
-    document = MagicMock()
-    document.did = file['object_id']
-    document.size = file['file_size']
-    document.hashes = { 'md5': file['md5sum'], 'other': 'abc123' }
-    document.acl = []
-    document.uploader = DEFAULT_SUBMITTER_ID
-    get_index_uuid.return_value = document
-    get_index_hash.return_value = document
-
-    # only return the correct document by uuid IF the uuid provided is
-    # the one from above
-    def get_index_by_uuid(uuid):
-        if uuid == document.did:
-            return document
-        else:
-            return None
-    get_index_uuid.side_effect = get_index_by_uuid
-
-    resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file)
-
-    # no index or alias creation
-    assert not create_index.called
-    assert not create_alias.called
-
-    # response
-    assert_positive_response(resp)
-    entity = assert_single_entity_from_response(resp)
-    assert entity['action'] == 'create'
-
-    path = '/v0/submission/CGCI/BLGSP/export/?format=json&ids={nid}'.format(nid=entity['id'])
-    r = client.get(
-        path,
-        headers=submitter)
-
-    data = r.json
-    assert len(data) == 1
-
-    # check that the acl and uploader fields have been updated in indexd (TODO)
-    # assert document.acl != []
-    # assert document.uploader == ''
 
 
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -677,3 +677,100 @@ def test_create_file_no_required_index(create_alias, create_index, get_index_uui
 
     data = r.json
     assert len(data) == 1
+
+
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
+def test_data_file_already_indexed_object_id_provided_hash_match(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, admin, submitter, cgci_blgsp):
+    """
+    Test submitting when the file is already indexed in the index client,
+    an id is provided in the submission, and the size and hash match those
+    of the indexed file.
+
+    The submission should succeed but no new index should be created.
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    # provide the object_id of an existing indexed file
+    file['object_id'] = '14fd1746-61bb-401a-96d2-342cfaf70000'
+
+    document = MagicMock()
+    document.did = file['object_id']
+    document.size = file['file_size']
+    document.hashes = { 'md5': file['md5sum'] }
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity['action'] == 'create'
+
+
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
+def test_data_file_already_indexed_object_id_provided_hash_no_match(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, admin, submitter, cgci_blgsp):
+    """
+    Test submitting when the file is already indexed in the index client,
+    its object_id is provided in the submission, and the size and hash DO NOT
+    match those of the indexed file.
+
+    The submission should fail.
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    # provide the object_id of an existing indexed file
+    file['object_id'] = '14fd1746-61bb-401a-96d2-342cfaf70000'
+
+    document = MagicMock()
+    document.did = file['object_id']
+    document.size = file['file_size'] + 10 # change hash/size
+    document.hashes = { 'md5': file['md5sum'] }
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_negative_response(resp)
+    entity = assert_single_entity_from_response(resp)

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -689,9 +689,11 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     """
     Test submitting when the file is already indexed in the index client,
     an id is provided in the submission, and the size and hash match those
-    of the indexed file.
+    of the indexed file. The empty acl means the file was just uploaded.
 
-    The submission should succeed but no new index should be created.
+    The submission should succeed but no new index should be created. The acl
+    and uploader field should have been updated as part of the data upload
+    flow.
     """
     submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
 
@@ -703,6 +705,8 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     document.did = file['object_id']
     document.size = file['file_size']
     document.hashes = { 'md5': file['md5sum'], 'other': 'abc123' }
+    document.acl = []
+    document.uploader = DEFAULT_SUBMITTER_ID
     get_index_uuid.return_value = document
     get_index_hash.return_value = document
 
@@ -727,6 +731,18 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     entity = assert_single_entity_from_response(resp)
     assert entity['action'] == 'create'
 
+    path = '/v0/submission/CGCI/BLGSP/export/?format=json&ids={nid}'.format(nid=entity['id'])
+    r = client.get(
+        path,
+        headers=submitter)
+
+    data = r.json
+    assert len(data) == 1
+
+    # check that the acl and uploader fields have been updated in indexd (TODO)
+    # assert document.acl != []
+    # assert document.uploader == ''
+
 
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
 @patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
@@ -738,9 +754,11 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     """
     Test submitting when the file is already indexed in the index client,
     its object_id is provided in the submission, and the size and hash DO NOT
-    match those of the indexed file.
+    match those of the indexed file. The empty acl means the file was just
+    uploaded.
 
-    The submission should fail.
+    The submission should fail. The acl and uploader field should NOT have
+    been updated.
     """
     submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
 
@@ -752,6 +770,8 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     document.did = file['object_id']
     document.size = file['file_size'] + 10 # change hash/size
     document.hashes = { 'md5': file['md5sum'] }
+    document.acl = []
+    document.uploader = DEFAULT_SUBMITTER_ID
     get_index_uuid.return_value = document
     get_index_hash.return_value = document
 
@@ -774,3 +794,64 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     # response
     assert_negative_response(resp)
     entity = assert_single_entity_from_response(resp)
+
+    # check that the acl and uploader fields have NOT been updated in indexd
+    assert document.acl == []
+    assert document.uploader == DEFAULT_SUBMITTER_ID
+
+
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index')
+@patch('sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias')
+def test_data_file_already_indexed_object_id_provided_no_hash(
+        create_alias, create_index, get_index_uuid, get_index_hash,
+        client, pg_driver, admin, submitter, cgci_blgsp):
+    """
+    Test submitting when the file is already indexed in the index client,
+    its object_id is provided in the submission, and the size and hash DO NOT
+    match those of the indexed file. The empty acl means the file was just
+    uploaded and the empty hash and size mean the file is not ready for
+    metadata submission yet.
+
+    The submission should fail. The acl and uploader field should NOT have
+    been updated.
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    # provide the object_id of an existing indexed file
+    file['object_id'] = '14fd1746-61bb-401a-96d2-342cfaf70000'
+
+    document = MagicMock()
+    document.did = file['object_id']
+    document.size = None
+    document.hashes = None
+    document.acl = []
+    document.uploader = DEFAULT_SUBMITTER_ID
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=file)
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_negative_response(resp)
+    entity = assert_single_entity_from_response(resp)
+
+    # check that the acl and uploader fields have NOT been updated in indexd
+    assert document.acl == []
+    assert document.uploader == DEFAULT_SUBMITTER_ID


### PR DESCRIPTION
Sheepdog update for data upload flow

### New Features
When object_id is provided for node registration:
- if the provided hash & size do not match those of the indexed file: error
- if current uploader = file uploader and file acl is empty: update acl and remove uploader in indexd. If not: error
- if the user is trying to submit a metadata node for a data file which the indexd listener has not yet registered (no hash and size): error.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

