### PR TITLE
Bump gdcdatamodel pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ xmltodict==0.9.2
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 -e git+https://git@github.com/uc-cdis/datadictionary.git@fd2fd659cff1ff002192d971082f68de1c514585#egg=gdcdictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.4#egg=gdcdatamodel
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.5#egg=gdcdatamodel
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

### Dependency updates

gdcdatamodel -> 1.3.5

### Deployment changes

To manually deploy the new indexes into existing commons run
```
gen3 psql sheepdog
CREATE INDEX snapshot_transaction_idx ON transaction_snapshots ( transaction_id );
CREATE INDEX document_transaction_idx ON transaction_documents ( transaction_id );
```