### PR TITLE
fix(unicode): don't cast to unicode for tsv

### DIFF
--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -51,16 +51,13 @@ def set_row_type(row):
 
 
 def strip(text):
-    """Strip text as unicode (which includes non-ascii whitespace).
-
-    this will cover a case if the value is NoneType
+    """
+    Strip if the text is a basestring
     """
 
     if not isinstance(text, basestring):
         return text
 
-    elif not isinstance(text, unicode):
-        return unicode(text, "UTF-8").strip()
 
     else:
         return text.strip()


### PR DESCRIPTION
the data coming in is already with proper encoding (ascii/utf-8), just use the encoded string to pass to transformation

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- csv library doesn't work with unicode, pass the original utf-8 encoded string instead

### Improvements


### Dependency updates


### Deployment changes

