### PR TITLE
[PXD-2275] Make required data_file field 'urls' visible to users in template TSVs and JSONs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+pytest==3.6.3
 pytest-cov==2.5.1
 requests_mock==1.4.0
 httmock==1.2.3

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -735,6 +735,9 @@ class ExportFile(object):
                 exclude_id=False,
             )
             self.templates[node.label] = props
+        # TODO: Explain
+        if 'urls' in props:
+            props.remove('urls')
         entity.update(get_node_link_json(node, props))
         entity.update(get_node_non_link_json(node, props))
         return entity

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -464,8 +464,10 @@ def entity_to_template_json(links, schema, exclude_id):
             keys[key] = schema['id']
         else:
             keys[key] = None
-    #TODO: Add explanation for below
-    #TODO: Add tests for below
+    # users need to submit the 'urls' field, but 'urls' is not in the schema
+    # (since it is a property of records in indexd, and is not in the dict).
+    # So we are adding it to the templates here.
+    # TODO: Add tests for below
     if schema['category'] == 'data_file':
         keys['urls'] = None
     return keys
@@ -513,7 +515,9 @@ def entity_to_template_delimited(links, schema, exclude_id):
                 keys.append(key + '.' + prop)
         else:
             keys.append(key)
-    #TODO: Add explanation for below
+    # users need to submit the 'urls' field, but 'urls' is not in the schema
+    # (since it is a property of records in indexd, and is not in the dict).
+    # So we are adding it to the templates here.
     #TODO: Add tests for below
     if schema['category'] == 'data_file':
         keys.append('urls')
@@ -735,7 +739,8 @@ class ExportFile(object):
                 exclude_id=False,
             )
             self.templates[node.label] = props
-        # TODO: Explain
+        # 'urls' is part of the templates but not part of the dicts 
+        # and not exported, so we remove it here
         if 'urls' in props:
             props.remove('urls')
         entity.update(get_node_link_json(node, props))

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -467,7 +467,6 @@ def entity_to_template_json(links, schema, exclude_id):
     # users need to submit the 'urls' field, but 'urls' is not in the schema
     # (since it is a property of records in indexd, and is not in the dict).
     # So we are adding it to the templates here.
-    # TODO: Add tests for below
     if schema['category'] == 'data_file':
         keys['urls'] = None
     return keys
@@ -518,7 +517,6 @@ def entity_to_template_delimited(links, schema, exclude_id):
     # users need to submit the 'urls' field, but 'urls' is not in the schema
     # (since it is a property of records in indexd, and is not in the dict).
     # So we are adding it to the templates here.
-    #TODO: Add tests for below
     if schema['category'] == 'data_file':
         keys.append('urls')
 
@@ -739,7 +737,7 @@ class ExportFile(object):
                 exclude_id=False,
             )
             self.templates[node.label] = props
-        # 'urls' is part of the templates but not part of the dicts 
+        # 'urls' is part of the templates but not part of the dicts
         # and not exported, so we remove it here
         if 'urls' in props:
             props.remove('urls')

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -464,6 +464,10 @@ def entity_to_template_json(links, schema, exclude_id):
             keys[key] = schema['id']
         else:
             keys[key] = None
+    #TODO: Add explanation for below
+    #TODO: Add tests for below
+    if schema['category'] == 'data_file':
+        keys['urls'] = None
     return keys
 
 
@@ -509,6 +513,10 @@ def entity_to_template_delimited(links, schema, exclude_id):
                 keys.append(key + '.' + prop)
         else:
             keys.append(key)
+    #TODO: Add explanation for below
+    #TODO: Add tests for below
+    if schema['category'] == 'data_file':
+        keys.append('urls')
 
     return keys
 

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -1,0 +1,26 @@
+import pytest
+from sheepdog import dictionary
+from sheepdog.utils.transforms.graph_to_doc import entity_to_template
+
+
+def test_urls_in_templates_json():
+    """Test that urls is in JSON template iff entity is data_file"""
+    for label in dictionary.schema:
+        if label == 'root':
+            continue
+        template = entity_to_template(label, file_format='json')
+        if dictionary.schema[label]['category'] == 'data_file':
+            assert 'urls' in template
+        else:
+            assert 'urls' not in template
+
+def test_urls_in_templates_tsv():
+    """Test that urls is in TSV template iff entity is data_file"""
+    for label in dictionary.schema:
+        if label == 'root':
+            continue
+        template = entity_to_template(label, file_format='tsv')
+        if dictionary.schema[label]['category'] == 'data_file':
+            assert 'urls' in template
+        else:
+            assert not 'urls' in template


### PR DESCRIPTION
- Adds 'urls' field to template TSVs and JSONs 
- Changes export logic to not check this new 'urls' field (because it's not in the dictionary)
- Unit tests for above 

(From Jira description:) 
To properly register data_files in Windmill, uses need to submit the metadata property 'urls' with the value of their s3 bucket location of the submitted file, for example:
"urls":"s3://data-bucket/folder1/file1.csv"
However, there is no "urls" in any of the data_file template tsvs, it is not in the form submission for data files, and it is not listed as a property in the data dictionary viewer, which results in a large amount of support intervention and user training.

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

- (incidental/unrelated to this issue) changes dev-requirements.txt to require pytest==3.6.3 because 4.0.1 breaks the tests

### Deployment changes
