### PR TITLE
fix(update-acl): use project code

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -612,7 +612,7 @@ class FileUploadEntity(UploadEntity):
 
         # update acl and uploader fields in indexd
         data = json.dumps({
-            'acl': ['read', 'write'],
+            'acl': [self.transaction.project],
             'uploader': None
         })
         url = '/index/' + self.object_id


### PR DESCRIPTION
Fix the ACL update of blank records

### New Features


### Breaking Changes


### Bug Fixes
- When linking metadata to an existing indexd record, set the ACL to the project the metadata is uploaded into

### Improvements


### Dependency updates


### Deployment changes

