### PR TITLE
chore(dictutils): bump dictutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.36.0
 cryptography==2.3
-dictionaryutils==2.0.0
+dictionaryutils==2.0.4
 envelopes==0.4
 Flask==0.12.4
 flask-cors==3.0.3
@@ -29,8 +29,8 @@ xmltodict==0.9.2
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
--e git+https://git@github.com/uc-cdis/datadictionary.git@fd2fd659cff1ff002192d971082f68de1c514585#egg=gdcdictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.4#egg=gdcdatamodel
+-e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.6#egg=gdcdatamodel
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- dictionaryutils 2.0.0 -> 2.0.4 to support nested subgroups
- gdcdatamodel 1.3.4 -> 1.3.6 to support nested subgroups

### Deployment changes

