### PR TITLE
Fix/data upload

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -227,9 +227,9 @@ class FileUploadEntity(UploadEntity):
                 # and node id.
                 # NOTE: The call below populates record errors
                 self._is_index_id_identical_to_node_id()
-            else:
-                if self.file_exists:
-                    self._is_valid_index_for_file()
+#             else:
+#                 if self.file_exists:
+#                     self._is_valid_index_for_file()
 
         return node
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -227,9 +227,9 @@ class FileUploadEntity(UploadEntity):
                 # and node id.
                 # NOTE: The call below populates record errors
                 self._is_index_id_identical_to_node_id()
-#             else:
-#                 if self.file_exists:
-#                     self._is_valid_index_for_file()
+            else:
+                if self.file_exists and not self.object_id:
+                    self._is_valid_index_for_file()
 
         return node
 


### PR DESCRIPTION
Fix bug where sheepdog tries to identify the file by hash/size during the data upload flow

### New Features


### Breaking Changes


### Bug Fixes
- In some cases, sheepdog tried to identify the file by hash/size even though the object_id was provided

### Improvements


### Dependency updates


### Deployment changes

