### PR TITLE
feat(upload): Restrict versioning nodes without changes in file_size or md5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -26,3 +26,4 @@ pyasn1-modules==0.0.11
 urllib3==1.22
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.0#egg=cirrus-0.0.0
 -e git+https://git@github.com/uc-cdis/fence.git@1.1.1#egg=fence
+google-resumable-media==0.3.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ SQLAlchemy==0.9.9
 codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
--e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.2.2#egg=cdisutilstest
+-e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.2.5#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@1.0.4#egg=indexd
 
 # indexd dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ xmltodict==0.9.2
 
 # required for gdcdatamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
+google-resumable-media==0.3.1

--- a/sheepdog/globals.py
+++ b/sheepdog/globals.py
@@ -224,6 +224,5 @@ UPDATABLE_FILE_STATES = [
 
 # Below is the list of node states that are treated as "released"
 RELEASED_NODE_STATES = [
-    'released',
-    'live',
+    'released'
 ]

--- a/sheepdog/test_settings.py
+++ b/sheepdog/test_settings.py
@@ -1,3 +1,4 @@
+import os
 from collections import OrderedDict
 from .config import LEGACY_MODE
 
@@ -41,8 +42,8 @@ SLICING = {
     'gencode': 'REPLACEME',
 }
 PSQL_USER_DB_NAME = 'test_userapi'
-PSQL_USER_DB_USERNAME = 'postgres'
-PSQL_USER_DB_PASSWORD = 'postgres'
+PSQL_USER_DB_USERNAME = os.environ.get('PSQL_USER_DB_USERNAME', 'postgres')
+PSQL_USER_DB_PASSWORD = os.environ.get('PSQL_USER_DB_PASSWORD', 'postgres')
 PSQL_USER_DB_HOST = 'localhost'
 
 PSQL_USER_DB_CONNECTION = "postgresql://{name}:{password}@{host}/{db}".format(

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -88,7 +88,7 @@ class UploadEntity(EntityBase):
         self._is_replaceable = self._config.get('CREATE_REPLACEABLE', False)
 
         self.old_uuid = None
-        self.transaction_roles = ["create", "update"]
+        self.create_update_roles = ["create", "update"]
 
     @property
     def secondary_keys(self):
@@ -220,7 +220,7 @@ class UploadEntity(EntityBase):
         """ Validate submitted file UUID if specified and record error if invalid. """
 
         self.entity_id = self.doc.get('id')
-        if self.transaction.role in self.transaction_roles and self.entity_id and not REGEX_UUID.match(self.entity_id):
+        if self.transaction.role in self.create_update_roles and self.entity_id and not REGEX_UUID.match(self.entity_id):
             self.record_error(
                 'Cannot create/update an entity with custom id that is not a UUID.',
                 keys=['id'], type=EntityErrors.INVALID_VALUE

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -253,7 +253,7 @@ class UploadEntity(EntityBase):
         Return:
             psqlgraph.Node: Node you just created
         """
-
+        self._set_entity_id()
         # Check user permissions for updating nodes
         roles = self.get_user_roles()
         if 'create' not in roles:
@@ -287,8 +287,6 @@ class UploadEntity(EntityBase):
                         .format(submitter_id),
                         keys=['submitter_id'],
                         type=EntityErrors.NOT_FOUND)
-
-        self._set_entity_id()
 
         # Assert that the node doesn't already exist
         if not skip_node_lookup:

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -698,7 +698,7 @@ class FileUploadEntity(UploadEntity):
 
     def _is_modified_release_node(self, node):
         """ Checks if the current entity"""
-        return node is not None and node.state == RELEASED_NODE_STATES and \
+        return node is not None and node.state in RELEASED_NODE_STATES and \
             (self.old_props.get("file_size") != self._get_file_size() or
              self.old_props.get("md5sum") != self.doc.get("md5sum"))
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -233,7 +233,7 @@ class FileUploadEntity(UploadEntity):
                 if not self.file_exists:
                     self._register_index()
 
-            # role will only be set to version is node passed is_versionable check
+            # role will only be set to version if node passed the _should_version_node check
             elif role == 'version':
                 self._new_version_index()
 
@@ -698,7 +698,7 @@ class FileUploadEntity(UploadEntity):
 
     def _is_modified_release_node(self, node):
         """ Checks if the current entity"""
-        return node is not None and node.state == "released" and \
+        return node is not None and node.state == RELEASED_NODE_STATES and \
             (self.old_props.get("file_size") != self._get_file_size() or
              self.old_props.get("md5sum") != self.doc.get("md5sum"))
 

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -389,7 +389,8 @@ class BulkUploadTransaction(TransactionBase):
             return self.rollback()
 
         try:
-            self.flush()
+            # flush already called from transaction worker, this leads to duplicate calls to entity.flush_to_session()
+            # self.flush()
             self.session.commit()
             self.set_transaction_log_state(TX_LOG_STATE_SUCCEEDED)
         except Exception as e:  # pylint: disable=broad-except

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,6 @@ from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel import models as md
 from gdcdatamodel.models import Edge, Node
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
@@ -331,19 +330,3 @@ def dictionary_setup(_app):
             _app.register_blueprint(sheepdog_blueprint, url_prefix='/v0/submission')
         except AssertionError:
             _app.logger.info('Blueprint is already registered!!!')
-
-
-@pytest.fixture
-def released_nodes(pg_driver, indexd_client):
-    with pg_driver.session_scope():
-        doc = create_random_index(indexd_client)
-        node = md.AlignedReads(node_id=doc.did,
-                            state="released",
-                            submitter_id="TEST",
-                            project_id="TEST-TEST",
-                            file_size=doc.size,
-                            md5sum=doc.hashes["md5"])
-        pg_driver.node_insert(node)
-    yield doc.did
-    with pg_driver.session_scope():
-        pg_driver.node_delete(node_id=doc.did)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-import
 import os
 import json
+import uuid
 
 import pytest
 import requests
@@ -10,9 +11,11 @@ from cdisutilstest.code.conftest import (
     indexd_client,
     indexd_server,
 )
+from cdisutilstest.code.indexd_fixture import create_random_index
+
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel.models import Edge, Node
+from gdcdatamodel.models import Edge, Node, AlignedReads
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
 from userdatamodel.driver import SQLAlchemyDriver
@@ -327,3 +330,19 @@ def dictionary_setup(_app):
             _app.register_blueprint(sheepdog_blueprint, url_prefix='/v0/submission')
         except AssertionError:
             _app.logger.info('Blueprint is already registered!!!')
+
+
+@pytest.fixture
+def released_nodes(pg_driver, indexd_client):
+    with pg_driver.session_scope():
+        doc = create_random_index(indexd_client)
+        node = AlignedReads(node_id=doc.did,
+                            state="released",
+                            submitter_id="TEST",
+                            project_id="TEST-TEST",
+                            file_size=doc.size,
+                            md5sum=doc.hashes["md5"])
+        pg_driver.node_insert(node)
+    yield doc.did
+    with pg_driver.session_scope():
+        pg_driver.node_delete(node_id=doc.did)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,8 @@ from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel.models import Edge, Node, AlignedReads
+from gdcdatamodel import models as md
+from gdcdatamodel.models import Edge, Node
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
 from userdatamodel.driver import SQLAlchemyDriver
@@ -336,7 +337,7 @@ def dictionary_setup(_app):
 def released_nodes(pg_driver, indexd_client):
     with pg_driver.session_scope():
         doc = create_random_index(indexd_client)
-        node = AlignedReads(node_id=doc.did,
+        node = md.AlignedReads(node_id=doc.did,
                             state="released",
                             submitter_id="TEST",
                             project_id="TEST-TEST",

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -799,8 +799,3 @@ def test_links_inherited_for_file_nodes(
         # Edges were relinked properly
         assert edges_in_new == edges_in_old
         assert edges_out_new == edges_out_old
-
-
-def test_detect_modified_released_node(indexd_client, pg_driver, released_nodes):
-    print released_nodes
-    assert 1 == 1

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -322,7 +322,7 @@ def test_is_updatable_file(client, pg_driver, indexd_client):
 
     # Create dummy file node and corresponding indexd record
     node = SubmittedAlignedReads(did)
-    indexd_client.create(
+    doc = indexd_client.create(
         did=did,
         urls=[url],
         hashes={'md5': '0'*32},
@@ -332,6 +332,8 @@ def test_is_updatable_file(client, pg_driver, indexd_client):
     transaction = MagicMock()
     transaction.indexd = indexd_client
     entity = FileUploadEntity(transaction)
+    entity.doc["md5sum"] = doc.hashes["md5"]
+    entity.doc["file_size"] = doc.size
     entity.s3_url = url
 
     for file_state in UPDATABLE_FILE_STATES:
@@ -340,6 +342,7 @@ def test_is_updatable_file(client, pg_driver, indexd_client):
         set_indexd_state(indexd_doc, url, file_state)
 
         # check if updatable
+        entity._populate_file_exist_in_index()
         assert entity.is_updatable_file_node(node)
 
 
@@ -798,5 +801,6 @@ def test_links_inherited_for_file_nodes(
         assert edges_out_new == edges_out_old
 
 
-def test_detect_modified_released_node(indexd_client, pg_driver, released_node):
-    assert 1 == 0
+def test_detect_modified_released_node(indexd_client, pg_driver, released_nodes):
+    print released_nodes
+    assert 1 == 1

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import re
+import uuid
 
 import pytest
 
@@ -795,3 +796,7 @@ def test_links_inherited_for_file_nodes(
         # Edges were relinked properly
         assert edges_in_new == edges_in_old
         assert edges_out_new == edges_out_old
+
+
+def test_detect_modified_released_node(indexd_client, pg_driver, released_node):
+    assert 1 == 0

--- a/tests/integration/submission/test_versioning.py
+++ b/tests/integration/submission/test_versioning.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 import os
 from gdcdatamodel import models as md
@@ -204,6 +206,7 @@ def test_creating_new_versioned_file(
                 submitter,
                 method='put',
                 sur_filename=file_name,
+                file_size=random.randint(19, 300)
             )
 
         did = sur_entity['id']


### PR DESCRIPTION
Adds an extra check to restrict versioning released nodes that does not include a change in either md5 or file_size