### PR TITLE
feat(upload): set submitter_id with new_submiter_id

### DIFF
--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -496,6 +496,7 @@ class UploadEntity(EntityBase):
 
         # At this point doc has been parsed, remove open_acl to avoid invalid property error
         self.doc.pop("open_acl", None)
+        new_submitter_id = self.doc.pop("new_submitter_id", None)
 
         # Set properties
         for key, val in self.doc.iteritems():
@@ -543,7 +544,10 @@ class UploadEntity(EntityBase):
             # Otherwise, set the value
             else:
                 try:
-                    self.node._props[key] = val
+                    if key == "submitter_id" and new_submitter_id:
+                        self.node._props[key] = new_submitter_id
+                    else:
+                        self.node._props[key] = val
                 except Exception as e:  # pylint: disable=broad-except
                     self.record_error(
                         'Invalid property ({}): {}'.format(key, str(e)),

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -875,3 +875,29 @@ def test_trigger_versioning(trigger, data_release, released_file, client,
     # assert new version was created on indexd
     doc = indexd_client.get(version_id)
     assert doc.version is None
+
+
+def test_update_node_submitter_id(
+        client, pg_driver, admin, submitter, cgci_blgsp, indexd_client):
+    """ Test updating an existing node's submitter id """
+    submit_first_experiment(client, submitter)
+
+    # submit metadata file once
+    metadata_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    metadata_file['id'] = DEFAULT_UUID
+
+    resp = submit_metadata_file(client, admin, submitter, data=metadata_file)
+    entity = assert_single_entity_from_response(resp)
+    assert_positive_response(resp)
+    assert entity['action'] == 'create'
+
+    # submit same metadata file again (with or without id provided)
+    metadata_file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    metadata_file["new_submitter_id"] = "Z"
+    resp1 = submit_metadata_file(client, admin, submitter, data=metadata_file)
+    assert_single_entity_from_response(resp1)
+    assert_positive_response(resp1)
+
+    with pg_driver.session_scope():
+        node = pg_driver.nodes().get(DEFAULT_UUID)
+        assert node.submitter_id == metadata_file["new_submitter_id"]


### PR DESCRIPTION
Adds check if uploaded document has `new_submitter_id` and set as the submitter_id