### PR TITLE
fix(urls-export)

### DIFF
--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -833,7 +833,10 @@ def export_all(node_label, project_id, file_format, db, **kwargs):
             if is_link_field(title):
                 titles_linked.append(title)
             else:
-                titles_non_linked.append(title)
+                # 'urls' is part of the templates but not part of the dicts
+                # and not exported, so we remove it here
+                if title != 'urls':
+                    titles_non_linked.append(title)
         titles = titles_non_linked + titles_linked
         # Example ``titles``:
         #


### PR DESCRIPTION
Fix bug in Sheepdog's `export all` endpoint (`export/?node_label=xxx`), which tried to export the `urls` of a data node

### New Features


### Breaking Changes


### Bug Fixes
- remove the urls from the exported fields

### Improvements


### Dependency updates


### Deployment changes

