### PR TITLE
fix(data-upload-acl)

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -612,7 +612,7 @@ class FileUploadEntity(UploadEntity):
 
         # update acl and uploader fields in indexd
         data = json.dumps({
-            'acl': [self.transaction.program, self.transaction.project],
+            'acl': self.transaction.get_phsids(),
             'uploader': None
         })
         url = '/index/' + self.object_id


### PR DESCRIPTION
When an uploaded file is mapped, set the ACL to `[program, project.dbgap_accession_number]` instead of `[program, project.code]`

### Bug Fixes
- Fixes a bug where a user could not download a file they have access to
