### PR TITLE
fix(upload): handle validated file state for released files

### DIFF
--- a/sheepdog/globals.py
+++ b/sheepdog/globals.py
@@ -225,10 +225,7 @@ UPDATABLE_FILE_STATES = [
 ]
 
 # files states that node modification is allowed for when node is released
-MODIFIABLE_FILE_STATES = [
-    'registered',
-    'uploading',
-    'uploaded',
+MODIFIABLE_RELEASED_FILE_STATES = [
     'validated'
 ]
 

--- a/sheepdog/globals.py
+++ b/sheepdog/globals.py
@@ -224,6 +224,14 @@ UPDATABLE_FILE_STATES = [
     'error',
 ]
 
+# files states that node modification is allowed for when node is released
+MODIFIABLE_FILE_STATES = [
+    'registered',
+    'uploading',
+    'uploaded',
+    'validated'
+]
+
 # Below is the list of node states that are treated as "released"
 RELEASED_NODE_STATES = [
     'released'

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -5,13 +5,11 @@ uploaded entities.
 import uuid
 
 import psqlgraph
-from indexclient.client import Document, UPDATABLE_ATTRS
+from indexclient.client import Document
 from sheepdog.utils import (
     lookup_project,
     is_project_public,
     generate_s3_url,
-    get_indexd_state,
-    get_indexd,
 )
 
 from sheepdog.transactions.entity_base import EntityErrors

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,6 @@ from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel import models as md
 from gdcdatamodel.models import Edge, Node
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
@@ -331,19 +330,3 @@ def dictionary_setup(_app):
             _app.register_blueprint(sheepdog_blueprint, url_prefix='/v0/submission')
         except AssertionError:
             _app.logger.info('Blueprint is already registered!!!')
-
-
-@pytest.fixture
-def released_nodes(pg_driver, indexd_client):
-    with pg_driver.session_scope():
-        doc = create_random_index(indexd_client)
-        node = md.AlignedReads(node_id=doc.did,
-                            state="released",
-                            submitter_id="TEST",
-                            project_id="TEST-TEST",
-                            file_size=doc.size,
-                            md5sum=doc.hashes["md5"])
-        pg_driver.node_insert(node)
-    yield doc.did
-    with pg_driver.session_scope():
-        pg_driver.node_delete(node_id=doc.did)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,8 @@ from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel.models import Edge, Node, AlignedReads
+from gdcdatamodel import models as md
+from gdcdatamodel.models import Edge, Node
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
 from userdatamodel.driver import SQLAlchemyDriver
@@ -336,7 +337,7 @@ def dictionary_setup(_app):
 def released_nodes(pg_driver, indexd_client):
     with pg_driver.session_scope():
         doc = create_random_index(indexd_client)
-        node = AlignedReads(node_id=doc.did,
+        node = md.AlignedReads(node_id=doc.did,
                             state="released",
                             submitter_id="TEST",
                             project_id="TEST-TEST",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,9 @@
 # pylint: disable=unused-import
+import hashlib
 import os
 import json
+import random
+
 import uuid
 
 import pytest
@@ -11,11 +14,10 @@ from cdisutilstest.code.conftest import (
     indexd_client,
     indexd_server,
 )
-from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel.models import Edge, Node
+from gdcdatamodel import models as m
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
 from userdatamodel.driver import SQLAlchemyDriver
@@ -33,6 +35,7 @@ from sheepdog.test_settings import (
 )
 from sheepdog import test_settings
 from tests.integration.api import app as _app, app_init
+from tests.integration.submission.test_upload import DEFAULT_URL
 
 try:
     reload  # Python 2.7
@@ -124,11 +127,11 @@ def pg_driver(request, client):
 
     def tearDown():
         with pg_driver.engine.begin() as conn:
-            for table in Node().get_subclass_table_names():
-                if table != Node.__tablename__:
+            for table in m.Node().get_subclass_table_names():
+                if table != m.Node.__tablename__:
                     conn.execute('delete from {}'.format(table))
-            for table in Edge().get_subclass_table_names():
-                if table != Edge.__tablename__:
+            for table in m.Edge().get_subclass_table_names():
+                if table != m.Edge.__tablename__:
                     conn.execute('delete from {}'.format(table))
             conn.execute('delete from versioned_nodes')
             conn.execute('delete from _voided_nodes')
@@ -330,3 +333,92 @@ def dictionary_setup(_app):
             _app.register_blueprint(sheepdog_blueprint, url_prefix='/v0/submission')
         except AssertionError:
             _app.logger.info('Blueprint is already registered!!!')
+
+
+@pytest.fixture
+def data_release(pg_driver):
+    """
+    Args:
+        pg_driver (psqlgraph.PsqlGraphDriver):
+    """
+    releases = []
+    with pg_driver.session_scope() as sxn:
+        release = m.DataRelease(node_id=str(uuid.uuid4()))
+        release.major_version = 10
+        release.minor_version = 2
+        release.released = True
+        release.release_data = '2018-09-27'
+
+        sxn.add(release)
+        releases.append(release)
+        r2 = m.DataRelease(node_id=str(uuid.uuid4()))
+        r2.major_version = 11
+        r2.minor_version = 0
+        r2.released = False
+        sxn.add(r2)
+        releases.append(r2)
+
+    # return current release number same as the data_release with released==False
+    yield "11.0"
+    with pg_driver.session_scope() as sxn:
+        for release in releases:
+            sxn.delete(release)
+
+
+@pytest.fixture
+def released_file(pg_driver, indexd_client, data_release):
+    """
+    Args:
+        pg_driver (psqlgraph.PsqlGraphDriver):
+    """
+    doc = create_random_index(indexd_client, release=data_release)
+
+    # create node
+    with pg_driver.session_scope() as sxn:
+        exp = m.ExperimentalMetadata(node_id=doc.did)
+        exp.submitter_id = "0"
+        exp.state = "released"
+        exp.project_id = 'CGCI-BLGSP'
+        exp.file_state = "validated"
+        pg_driver.node_insert(exp)
+    yield doc
+    doc = indexd_client.get(doc.did)
+    doc.delete()
+
+    with pg_driver.session_scope() as sxn:
+        sxn.delete(exp)
+
+
+def create_random_index(index_client, release):
+    """
+    Shorthand for creating new index entries for test purposes.
+    Note:
+        Expects index client v1.5.2 and above
+    Args:
+        index_client (indexclient.client.IndexClient): pytest fixture for index_client
+        passed from actual test functions
+        release (str): release number
+    Returns:
+        indexclient.client.Document: the document just created
+    """
+
+    did = str(uuid.uuid4())
+
+    md5_hasher = hashlib.md5()
+    md5_hasher.update(did.encode("utf-8"))
+    hashes = {'md5': md5_hasher.hexdigest()}
+
+    metadata = {"release_number": release} if release else {}
+    doc = index_client.create(
+        did=did,
+        hashes=hashes,
+        size=random.randint(10, 1000),
+        acl=["a", "b"],
+        version="1",
+        metadata=metadata,
+        file_name="{}_warning_huge_file.svs".format(did),
+        urls=[DEFAULT_URL],
+        urls_metadata={DEFAULT_URL: {"state": "validated", "type": "cleversafe"}}
+    )
+
+    return doc

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,7 @@ from cdisutilstest.code.indexd_fixture import create_random_index
 
 from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
-from gdcdatamodel.models import Edge, Node
+from gdcdatamodel.models import Edge, Node, AlignedReads
 from userdatamodel import models as usermd
 from userdatamodel import Base as usermd_base
 from userdatamodel.driver import SQLAlchemyDriver
@@ -330,3 +330,19 @@ def dictionary_setup(_app):
             _app.register_blueprint(sheepdog_blueprint, url_prefix='/v0/submission')
         except AssertionError:
             _app.logger.info('Blueprint is already registered!!!')
+
+
+@pytest.fixture
+def released_nodes(pg_driver, indexd_client):
+    with pg_driver.session_scope():
+        doc = create_random_index(indexd_client)
+        node = AlignedReads(node_id=doc.did,
+                            state="released",
+                            submitter_id="TEST",
+                            project_id="TEST-TEST",
+                            file_size=doc.size,
+                            md5sum=doc.hashes["md5"])
+        pg_driver.node_insert(node)
+    yield doc.did
+    with pg_driver.session_scope():
+        pg_driver.node_delete(node_id=doc.did)

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -6,7 +6,6 @@ import copy
 import json
 import os
 import re
-import uuid
 
 import pytest
 
@@ -23,13 +22,13 @@ except ImportError:
     from mock import patch
 
 from gdcdatamodel.models import SubmittedAlignedReads, Case
-from sheepdog.globals import UPDATABLE_FILE_STATES, RELEASED_NODE_STATES, MODIFIABLE_FILE_STATES
+from sheepdog.globals import UPDATABLE_FILE_STATES, RELEASED_NODE_STATES
 from sheepdog.transactions.upload.sub_entities import FileUploadEntity
 from sheepdog.test_settings import SUBMISSION
 from sheepdog.utils import (
     generate_s3_url,
-    set_indexd_state,
-    get_indexd)
+    set_indexd_state
+)
 from tests.integration.submission.test_versioning import release_indexd_doc
 from tests.integration.submission.utils import (
     data_file_creation, read_json_data, put_entity_from_file

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -807,7 +807,7 @@ def test_links_inherited_for_file_nodes(
         'CREATE_REPLACEABLE': True
     }
 )
-def test_silently_update_released_node(data_release, released_file, client, modifiable_state,
+def test_silently_update_released_node(data_release, released_file, client,
                                        admin, submitter, cgci_blgsp, indexd_client, pg_driver):
 
     submit_first_experiment(client, submitter)

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -801,5 +801,6 @@ def test_links_inherited_for_file_nodes(
         assert edges_out_new == edges_out_old
 
 
-def test_detect_modified_released_node(indexd_client, pg_driver, released_node):
-    assert 1 == 0
+def test_detect_modified_released_node(indexd_client, pg_driver, released_nodes):
+    print released_nodes
+    assert 1 == 1

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -799,8 +799,3 @@ def test_links_inherited_for_file_nodes(
         # Edges were relinked properly
         assert edges_in_new == edges_in_old
         assert edges_out_new == edges_out_old
-
-
-def test_detect_modified_released_node(indexd_client, pg_driver, released_nodes):
-    print released_nodes
-    assert 1 == 1

--- a/tests/integration/submission/test_upload.py
+++ b/tests/integration/submission/test_upload.py
@@ -799,3 +799,7 @@ def test_links_inherited_for_file_nodes(
         # Edges were relinked properly
         assert edges_in_new == edges_in_old
         assert edges_out_new == edges_out_old
+
+
+def test_detect_modified_released_node(indexd_client, pg_driver, released_node):
+    assert 1 == 0

--- a/tests/integration/submission/test_versioning.py
+++ b/tests/integration/submission/test_versioning.py
@@ -190,7 +190,7 @@ def test_creating_new_versioned_file(
     """
     Create a new version of a file
     """
-    def create_node(version_number=None, file_name=file_name, release="10.0"):
+    def create_node(version_number=None, file_name=file_name, release=None):
         """Create a node and possibly assign it a version
 
         Args:
@@ -201,13 +201,15 @@ def test_creating_new_versioned_file(
             str: UUID of node submitted to the api
         """
         # Patch open file type to test open access file with type SubmittedAlignedReads
+        # random file_size
+        file_size = 55 * int(version_number) if version_number else 11
         with patch.object(FileUploadEntity, "get_open_file_type", lambda x: ["submitted_aligned_reads"]):
             _, sur_entity = data_file_creation(
                 client_toggled,
                 submitter,
                 method='put',
                 sur_filename=file_name,
-                file_size=random.randint(19, 300)
+                file_size=file_size
             )
 
         did = sur_entity['id']

--- a/tests/integration/submission/test_versioning.py
+++ b/tests/integration/submission/test_versioning.py
@@ -190,12 +190,13 @@ def test_creating_new_versioned_file(
     """
     Create a new version of a file
     """
-    def create_node(version_number=None, file_name=file_name):
+    def create_node(version_number=None, file_name=file_name, release="10.0"):
         """Create a node and possibly assign it a version
 
         Args:
-            version_number (int): whole number to indicate a version
-
+            version_number (str): whole number to indicate a version
+            file_name (str):
+            release (str):
         Returns:
             str: UUID of node submitted to the api
         """
@@ -228,7 +229,7 @@ def test_creating_new_versioned_file(
         # only give a version number if one is supplied
         if version_number:
             # simulate release by incrementing all versions for similar docs
-            release_indexd_doc(pg_driver, indexd_client, did)
+            release_indexd_doc(pg_driver, indexd_client, did, release)
 
             indexd_doc = indexd_client.get(did)
             message = 'Should have been assigned version {}'.format(
@@ -240,7 +241,7 @@ def test_creating_new_versioned_file(
     # create nodes and release a few times, just to be sure
     # create versions 1, 2, 3, None (no version on the last one)
     accepted_versions = ['1', '2', '3', None]
-    uuids = [create_node(version_number=v) for v in accepted_versions]
+    uuids = [create_node(version_number=v, release="10.{}".format(v)) for v in accepted_versions]
     created_versions = [indexd_client.get(uuid) for uuid in uuids]
     # this order is guaranteed
     for created, accepted in zip(created_versions, accepted_versions):

--- a/tests/integration/submission/test_versioning.py
+++ b/tests/integration/submission/test_versioning.py
@@ -1,5 +1,3 @@
-import random
-
 import pytest
 import os
 from gdcdatamodel import models as md

--- a/tests/integration/submission/utils.py
+++ b/tests/integration/submission/utils.py
@@ -204,13 +204,14 @@ def data_file_creation(client, headers, method='post', sur_filename='',
     return resp.json, sur_entity
 
 
-def release_indexd_doc(pg_driver, indexd_client, latest_did):
+def release_indexd_doc(pg_driver, indexd_client, latest_did, release_number=None):
     """Simulate a released node in indexd
 
     Args:
         pg_driver (pytest fixture): client connected to postgres server
         indexd_client (pytest fixture): client connected to indexd server
         latest_did (str): did of a document in indexd
+        release_number (str): current open release number
     """
 
     indexd_doc = indexd_client.get(latest_did)
@@ -229,4 +230,5 @@ def release_indexd_doc(pg_driver, indexd_client, latest_did):
     # create newest version number
     new_version = int(max([d.version for d in docs]) or '0') + 1
     indexd_doc.version = str(new_version)
+    indexd_doc.metadata["release_number"] = release_number if release_number else "10.0"
     indexd_doc.patch()


### PR DESCRIPTION
Adds support for silently updating released file metadata without creating a new version