### PR TITLE
fix/snapshots: fix 500 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ xmltodict==0.9.2
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 -e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.6#egg=gdcdatamodel
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@e72d3acb931dcad3e3a7e0fcd335f9259992df1e#egg=gdcdatamodel
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ xmltodict==0.9.2
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 -e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@e72d3acb931dcad3e3a7e0fcd335f9259992df1e#egg=gdcdatamodel
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@1.3.7#egg=gdcdatamodel
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -85,8 +85,9 @@ def db_init(app):
 
 
 def migrate_database(app):
-    if postgres_admin.check_version(app.db):
-        return
+    # TODO: uncomment
+    #if postgres_admin.check_version(app.db):
+    #    return
     try:
         postgres_admin.create_graph_tables(app.db, timeout=1)
     except Exception:

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -116,21 +116,6 @@ def migrate_database(app):
             app.logger.warn("Fail to grant read permission, continuing anyway")
             return
 
-    # migrate transaction snapshots
-    # old id column -> entity_id column, not unique
-    md = MetaData(bind=app.db.engine)
-    tablename = models.submission.TransactionSnapshot.__tablename__
-    snapshots_table = Table(tablename, md, autoload=True)
-    if "entity_id" not in snapshots_table.c:
-        with app.db.session_scope() as session:
-            session.execute(
-                "ALTER TABLE {name} DROP CONSTRAINT {name}_pkey".format(name=tablename)
-            )
-            session.execute("ALTER TABLE {} RENAME id TO entity_id".format(tablename))
-            session.execute(
-                "ALTER TABLE {} ADD COLUMN id SERIAL PRIMARY KEY;".format(tablename)
-            )
-
 
 def app_init(app):
     # Register duplicates only at runtime

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -86,6 +86,7 @@ def db_init(app):
 
 
 def migrate_database(app):
+    postgres_admin.migrate_transaction_snapshots(app.db, read_role)
     if postgres_admin.check_version(app.db):
         return
     try:

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -121,14 +121,16 @@ def migrate_database(app):
     # old id column -> entity_id column, not unique
     md = MetaData(bind=app.db.engine)
     tablename = models.submission.TransactionSnapshot.__tablename__
-    with app.db.session_scope() as session:
-        session.execute(
-            "ALTER TABLE {name} DROP CONSTRAINT {name}_pkey".format(name=tablename)
-        )
-        session.execute("ALTER TABLE {} RENAME id TO entity_id".format(tablename))
-        session.execute(
-            "ALTER TABLE {} ADD COLUMN id SERIAL PRIMARY KEY;".format(tablename)
-        )
+    snapshots_table = Table(tablename, md, autoload=True)
+    if "entity_id" not in snapshots_table.c:
+        with app.db.session_scope() as session:
+            session.execute(
+                "ALTER TABLE {name} DROP CONSTRAINT {name}_pkey".format(name=tablename)
+            )
+            session.execute("ALTER TABLE {} RENAME id TO entity_id".format(tablename))
+            session.execute(
+                "ALTER TABLE {} ADD COLUMN id SERIAL PRIMARY KEY;".format(tablename)
+            )
 
 
 def app_init(app):

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -86,9 +86,8 @@ def db_init(app):
 
 
 def migrate_database(app):
-    # TODO: uncomment
-    #if postgres_admin.check_version(app.db):
-    #    return
+    if postgres_admin.check_version(app.db):
+        return
     try:
         postgres_admin.create_graph_tables(app.db, timeout=1)
     except Exception:

--- a/sheepdog/transactions/transaction_base.py
+++ b/sheepdog/transactions/transaction_base.py
@@ -450,7 +450,7 @@ class TransactionBase(object):
                 if not entity.node or isinstance(entity.node, MissingNode):
                     continue
                 snapshot = models.submission.TransactionSnapshot()
-                snapshot.id = entity.node.node_id
+                snapshot.entity_id = entity.node.node_id
                 snapshot.old_props = entity.old_props
                 snapshot.new_props = entity.node.props
                 snapshot.action = entity.action

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -448,7 +448,7 @@ class BulkUploadTransaction(TransactionBase):
             if self.success:
                 for entity in self.entities:
                     snapshot = models.submission.TransactionSnapshot()
-                    snapshot.id = entity.node.node_id
+                    snapshot.entity_id = entity.node.node_id
                     snapshot.old_props = entity.old_props
                     snapshot.new_props = entity.node.props
                     snapshot.action = entity.action


### PR DESCRIPTION
Fixes a 500 error when trying to create multiple entries with the same submitter id in the same transaction (correctly returns 400).

DEPENDS ON:
- [x] https://github.com/uc-cdis/gdcdatamodel/pull/11

### Bug Fixes

- Make entity ID a separate and non-unique column on transaction snapshots.
- Change the ID column to be a real internal primary key.