### PR TITLE
fix(tl): Remove drop all

### DIFF
--- a/bin/setup_transactionlogs.py
+++ b/bin/setup_transactionlogs.py
@@ -14,7 +14,6 @@ def setup(host, user, password, database):
             user=user, host=host, password=password, database=database
         )
     )
-    Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
 
 


### PR DESCRIPTION

### New Features

### Breaking Changes


### Bug Fixes
Removes the drop_all in the transaction log setup. This was wiping the transaction logs for the docker-compose version of Gen3.

### Improvements


### Dependency updates


### Deployment changes

