### PR TITLE
fix(deadlock): un-lazy uwsgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ which by default will output the `index.html` page to
 
 [OpenAPI documentation available here.](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/sheepdog/master/openapi/swagger.yml)
 
-The YAML file comtaining the OpenAPI documentation can be found in the `openapi` folder; see the README in that folder for more details.
+The YAML file comtaining the OpenAPI documentation is in the `openapi` folder;
+see the README in that folder for more details.
+

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -21,8 +21,3 @@ gid = www-data
 pythonpath = /var/www/sheepdog/
 pythonpath = /sheepdog/
 pythonpath = /usr/local/lib/python2.7/dist-packages/
-
-# Initialize application in worker processes, not master. This prevents the
-# workers from all trying to open the same database connections at startup.
-lazy = true
-lazy-apps = true


### PR DESCRIPTION
### Bug Fixes

Don't use lazy application initialization setting in uwsgi, which was causing multiple workers to try to open the database simultaneously (and fail if they couldn't).