### PR TITLE
fix(more-itertools): pin version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ simplejson==3.8.1
 sqlalchemy==0.9.9
 Werkzeug==0.12.2
 xmltodict==0.9.2
+more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils


### PR DESCRIPTION
Recent release from the python package `more-itertools` introduces an error on setup. Pin the old version.