### PR TITLE
chore(load-dict-local): fix loading dict locally

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,7 +7,6 @@ import os
 import requests
 
 from flask import current_app
-from gdcdatamodel import models as md
 from psqlgraph import PolyNode as Node
 
 from sheepdog.api import run_for_development
@@ -87,6 +86,8 @@ def set_user(*args, **kwargs):
 
 def run_with_fake_auth():
     def get_project_ids(role="_member_", project_ids=None):
+        from gdcdatamodel import models as md
+
         if project_ids is None:
             project_ids = []
         if not project_ids:


### PR DESCRIPTION
There was an import of `models` before the initialization of configured dictionary when run locally, which made the initialization of models not honor the actual dictionary. This patch fixes this issue.

### Bug Fixes
* Fix the bug loading the wrong dictionary when running locally with `run.py`