### PR TITLE
PXD-2916: implement uniqueKeys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
--e git+https://git@github.com/uc-cdis/datamodelutils.git@0.4.1#egg=datamodelutils
+datamodelutils==0.4.3
 psqlgraph==1.2.3
 -e git+https://git@github.com/NCI-GDC/signpost.git@v1.1#egg=signpost
 # required for gdcdatamodel, not required for sheepdog
@@ -31,7 +31,7 @@ psqlgraph==1.2.3
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 -e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
-gdcdatamodel==1.3.11
+gdcdatamodel==1.3.12
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/sheepdog/errors.py
+++ b/sheepdog/errors.py
@@ -23,3 +23,7 @@ class NoIndexForFileError(UserError):
             file_id
         )
         self.code = 400
+
+
+class HandledIntegrityError(Exception):
+    pass

--- a/sheepdog/transactions/upload/__init__.py
+++ b/sheepdog/transactions/upload/__init__.py
@@ -13,6 +13,7 @@ import lxml
 from sheepdog import auth
 from sheepdog import utils
 from sheepdog.errors import ParsingError, SchemaError, UnsupportedError, UserError
+from sheepdog.errors import HandledIntegrityError
 from sheepdog.globals import FLAG_IS_ASYNC, PROJECT_SEED
 from sheepdog.transactions.upload.transaction import (
     BulkUploadTransaction,
@@ -31,6 +32,8 @@ def single_transaction_worker(transaction, *doc_args):
             transaction.flush()
             transaction.post_validate()
             transaction.commit()
+        except HandledIntegrityError:
+            pass
         except UserError as e:
             transaction.record_user_error(e)
             raise

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -202,7 +202,8 @@ class UploadTransaction(TransactionBase):
                             break
                         entities.append(en)
                         label = en.node.label
-                else:
+                else:  # pylint: disable=useless-else-on-loop
+                    # https://github.com/PyCQA/pylint/pull/2760
                     for entity in entities:
                         entity.record_error(
                             "{} with {} already exists in the GDC".format(

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -2,16 +2,18 @@
 Define the ``UploadTransaction`` class.
 """
 
+import re
 from collections import Counter
 
 # Validating Entity Existence in dbGaP
 from datamodelutils import validators
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.attributes import flag_modified
 
 from sheepdog.auth import dbgap
 from sheepdog import models
 from sheepdog import utils
-from sheepdog.errors import UserError
+from sheepdog.errors import UserError, HandledIntegrityError
 from sheepdog.globals import (
     case_cache_enabled,
     TX_LOG_STATE_ERRORED,
@@ -21,6 +23,10 @@ from sheepdog.globals import (
 from sheepdog.transactions.upload.entity import EntityErrors
 from sheepdog.transactions.transaction_base import TransactionBase
 from sheepdog.transactions.upload.entity_factory import UploadEntityFactory
+
+
+KEYS_REGEXP = re.compile(r"_props ->> '([^']+)+'::text")
+VALUES_REGEXP = re.compile(r"=\(([^\(\)]+)\)")
 
 
 class UploadTransaction(TransactionBase):
@@ -172,7 +178,41 @@ class UploadTransaction(TransactionBase):
         """
         for entity in self.valid_entities:
             entity.flush_to_session()
-        self.session.flush()
+        try:
+            self.session.flush()
+        except IntegrityError as e:
+            # don't handle non-unique constraint errors
+            if 'duplicate key value violates unique constraint' not in e.message:
+                raise
+            values = VALUES_REGEXP.findall(e.message)
+            if not values:
+                raise
+            values = [v.strip() for v in values[0].split(',')]
+            keys = KEYS_REGEXP.findall(e.message)
+            if len(keys) == len(values):
+                values = dict(zip(keys, values))
+                entities = []
+                label = None
+                for en in self.valid_entities:
+                    for k, v in values.items():
+                        if getattr(en.node, k, None) != v:
+                            break
+                    else:
+                        if label and label != en.node.label:
+                            break
+                        entities.append(en)
+                        label = en.node.label
+                else:
+                    for entity in entities:
+                        entity.record_error(
+                            '{} with {} already exists in the GDC'
+                            .format(entity.node.label, values),
+                            keys=keys,
+                        )
+                    if entities:
+                        raise HandledIntegrityError()
+            self.record_error('{} already exists in the GDC'.format(values))
+            raise HandledIntegrityError()
 
     @property
     def status_code(self):

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -182,12 +182,12 @@ class UploadTransaction(TransactionBase):
             self.session.flush()
         except IntegrityError as e:
             # don't handle non-unique constraint errors
-            if 'duplicate key value violates unique constraint' not in e.message:
+            if "duplicate key value violates unique constraint" not in e.message:
                 raise
             values = VALUES_REGEXP.findall(e.message)
             if not values:
                 raise
-            values = [v.strip() for v in values[0].split(',')]
+            values = [v.strip() for v in values[0].split(",")]
             keys = KEYS_REGEXP.findall(e.message)
             if len(keys) == len(values):
                 values = dict(zip(keys, values))
@@ -205,13 +205,14 @@ class UploadTransaction(TransactionBase):
                 else:
                     for entity in entities:
                         entity.record_error(
-                            '{} with {} already exists in the GDC'
-                            .format(entity.node.label, values),
+                            "{} with {} already exists in the GDC".format(
+                                entity.node.label, values
+                            ),
                             keys=keys,
                         )
                     if entities:
                         raise HandledIntegrityError()
-            self.record_error('{} already exists in the GDC'.format(values))
+            self.record_error("{} already exists in the GDC".format(values))
             raise HandledIntegrityError()
 
     @property

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -206,14 +206,14 @@ class UploadTransaction(TransactionBase):
                     # https://github.com/PyCQA/pylint/pull/2760
                     for entity in entities:
                         entity.record_error(
-                            "{} with {} already exists in the GDC".format(
+                            "{} with {} already exists".format(
                                 entity.node.label, values
                             ),
                             keys=keys,
                         )
                     if entities:
                         raise HandledIntegrityError()
-            self.record_error("{} already exists in the GDC".format(values))
+            self.record_error("{} already exists".format(values))
             raise HandledIntegrityError()
 
     @property

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -654,7 +654,7 @@ def test_data_file_update_url_invalid_id(
     assert new_url not in document.urls
 
     # response
-    assert_negative_response(resp)
+    assert_negative_response(resp, on_entity=False)
     assert_single_entity_from_response(resp)
 
 
@@ -868,7 +868,7 @@ def test_data_file_update_url_id_provided_different_file_already_indexed(
     assert new_url not in different_file_matching_hash_and_size.urls
 
     # response
-    assert_negative_response(resp)
+    assert_negative_response(resp, on_entity=False)
     assert_single_entity_from_response(resp)
 
 

--- a/tests/integration/datadictwithobjid/submission/utils.py
+++ b/tests/integration/datadictwithobjid/submission/utils.py
@@ -96,13 +96,14 @@ def assert_positive_response(resp):
     assert resp.json["success"] is True
 
 
-def assert_negative_response(resp):
+def assert_negative_response(resp, on_entity=True):
     assert resp.status_code != 200, resp.data
     entities = resp.json["entities"]
 
     # check if at least one entity has an error
-    entity_errors = [entity["errors"] for entity in entities if entity["errors"]]
-    assert entity_errors
+    if on_entity:
+        entity_errors = [entity["errors"] for entity in entities if entity["errors"]]
+        assert entity_errors
 
     assert resp.json["success"] is False
 


### PR DESCRIPTION
Auto migration is in uc-cdis/datamodelutils#6.

uc-cdis/gdcdatamodel#12 replaced indexes on these columns with unique ones:

* `program.name`
* `project.code`

also added unique indexes for:

* `(project_id, submitter_id)` of other nodes

### Improvements

* added unique indexes for uniqueKeys

### Deployment changes

* Sheepdog will now create (or replace) the missing indexes during migration
* New unique indexes have been added to all nodes uc-cdis/gdcdatamodel#12