### PR TITLE
fix(dmu): fix migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 -e git+https://git@github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
--e git+https://git@github.com/uc-cdis/datamodelutils.git@0.4.1#egg=datamodelutils
+-e git+https://git@github.com/uc-cdis/datamodelutils.git@0.4.2#egg=datamodelutils
 -e git+https://git@github.com/NCI-GDC/psqlgraph.git@1.2.0#egg=psqlgraph
 -e git+https://git@github.com/NCI-GDC/signpost.git@v1.1#egg=signpost
 # required for gdcdatamodel, not required for sheepdog


### PR DESCRIPTION
Update to latest version of datamodelutils which fixes the transaction snapshots migration to allow `entity_id` to be null.