### PR TITLE
[PXP-2658] Upgrade PyYAML to 5.1 and use safe_load()

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
-PyYAML==4.2b1
+PyYAML==5.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@1.0.8#egg=indexd
 # indexd dependencies

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,6 @@ codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
-PyYAML==5.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@1.0.8#egg=indexd
 # indexd dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ lxml==3.8.0
 pbr==2.0.0
 psycopg2==2.7.3.2
 python-keystoneclient==1.8.1
-PyYAML==4.2b1
+PyYAML==5.1
 requests==2.20.0
 setuptools==30.1.0
 simplejson==3.8.1

--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -7,7 +7,6 @@ import uuid
 
 import flask
 import sqlalchemy
-import yaml
 
 from sheepdog import auth
 from sheepdog import dictionary

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -136,7 +136,7 @@ class BcrXmlToJsonParser(object):
         self.export_count = 0
         self.ignore_missing_properties = True
         self.xml_mapping = json.loads(
-            json.dumps(yaml.load(BCR_MAPPING)), object_hook=AttrDict
+            json.dumps(yaml.safe_load(BCR_MAPPING)), object_hook=AttrDict
         )
         self.entities = {}
 
@@ -594,7 +594,7 @@ class BcrClinicalXmlToJsonParser(object):
             mapping = pkg_resources.resource_string(
                 "gdcdatamodel", "xml_mappings/tcga_clinical.yaml"
             )
-        self.xpath_ref = yaml.load(mapping)
+        self.xpath_ref = yaml.safe_load(mapping)
         self.docs = []
 
     @property


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Use PyYaml safe_load() instead of load()

### Dependency updates
Upgrade PyYaml to 5.1

### Deployment changes

