### PR TITLE
PXP-2401 Fix/asterisk

### DIFF
--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -105,9 +105,6 @@ class UploadEntity(EntityBase):
                 ),
                 type=EntityErrors.INVALID_VALUE,
             )
-        # Remove asterisks from doc keys
-        for key in doc:
-            doc[key.lstrip("*")] = doc.pop(key)
 
         self.doc = doc
         self._parse_type()

--- a/sheepdog/transactions/upload/entity_factory.py
+++ b/sheepdog/transactions/upload/entity_factory.py
@@ -31,6 +31,10 @@ class UploadEntityFactory:
             #       more helpful debugging
             return UploadEntity(transaction, config)
 
+        # Remove asterisks from dict keys
+        for key in doc:
+            doc[key.lstrip("*")] = doc.pop(key)
+
         node_type = doc.get("type")
         node_category = get_node_category(node_type)
 

--- a/sheepdog/transactions/upload/entity_factory.py
+++ b/sheepdog/transactions/upload/entity_factory.py
@@ -32,7 +32,7 @@ class UploadEntityFactory:
             return UploadEntity(transaction, config)
 
         # Remove asterisks from dict keys
-        for key in doc:
+        for key in list(doc):
             doc[key.lstrip("*")] = doc.pop(key)
 
         node_type = doc.get("type")

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -135,7 +135,7 @@ class DelimitedConverter(object):
         row = strip_whitespace_from_str_dict(row)
 
         # Remove asterisks from dict keys
-        for key in row:
+        for key in list(row):
             row[key.lstrip("*")] = row.pop(key)
 
         # Parse type

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -133,6 +133,11 @@ class DelimitedConverter(object):
         """
         doc, links = {}, {}
         row = strip_whitespace_from_str_dict(row)
+
+        # Remove asterisks from dict keys
+        for key in row:
+            row[key.lstrip("*")] = row.pop(key)
+
         # Parse type
         cls = set_row_type(row)
         if cls is None:

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -589,6 +589,76 @@ def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter,
     assert index_client.get(sur_entity['id']), 'No indexd document created'
 
 
+def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
+    """
+    Test that we can submit a valid TSV file
+    """
+
+    data = {
+        "type": "experiment",
+        "submitter_id": "BLGSP-71-06-00019",
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    }
+
+    # convert to TSV (save to file)
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "data/experiment_tmp.tsv"
+    )
+    with open(file_path, "w") as f:
+        import csv
+        dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
+        dw.writeheader()
+        dw.writerow(data)
+
+    # read the TSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path) # clean up (delete file)
+    assert data
+
+    headers = submitter
+    headers["Content-Type"] = "text/tsv"
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+def test_submit_valid_csv(client, pg_driver, cgci_blgsp, submitter):
+    """
+    Test that we can submit a valid CSV file
+    """
+
+    data = {
+        "type": "experiment",
+        "submitter_id": "BLGSP-71-06-00019",
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    }
+
+    # convert to CSV (save to file)
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "data/experiment_tmp.csv"
+    )
+    with open(file_path, "w") as f:
+        import csv
+        dw = csv.DictWriter(f, sorted(data.keys()), delimiter=",")
+        dw.writeheader()
+        dw.writerow(data)
+
+    # read the CSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path) # clean up (delete file)
+    assert data
+
+    headers = submitter
+    headers["Content-Type"] = "text/csv"
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    assert resp.status_code == 200, resp.data
+
+
 def test_export_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
     post_example_entities_together(client, submitter)
     with pg_driver.session_scope():
@@ -646,8 +716,8 @@ def test_export_all_node_types_json(client, pg_driver, cgci_blgsp, submitter):
     assert len(js_data["data"]) == case_count
 
 
-# test that we can submit and export non-ascii characters without errors
 def test_submit_export_encoding(client, pg_driver, cgci_blgsp, submitter):
+    """Test that we can submit and export non-ascii characters without errors"""
     # submit metadata containing non-ascii characters
     headers = submitter
     data = json.dumps({

--- a/tests/integration/datadict/submission/test_upload.py
+++ b/tests/integration/datadict/submission/test_upload.py
@@ -59,11 +59,17 @@ def submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp):
     assert resp.status_code == 200, resp.data
 
 
-def submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp, data=None):
+def submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp, data=None, format="json"):
     data = data or DEFAULT_METADATA_FILE
+    headers = submitter
     put_cgci_blgsp(client, admin)
-    data = json.dumps(data)
-    resp = client.put(BLGSP_PATH, headers=submitter, data=data)
+    if format == "tsv":
+        headers["Content-Type"] = "text/tsv"
+    elif format == "csv":
+        headers["Content-Type"] = "text/csv"
+    else: # json
+        data = json.dumps(data)
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
     return resp
 
 
@@ -869,3 +875,149 @@ def test_create_file_no_required_index(
     assert_negative_response(resp)
     entity = assert_single_entity_from_response(resp)
     assert entity["action"] == "create"
+
+
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash"
+)
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid"
+)
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index")
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias")
+def test_submit_valid_tsv_data_file(
+    create_alias,
+    create_index,
+    get_index_uuid,
+    get_index_hash,
+    client,
+    pg_driver,
+    admin,
+    submitter,
+    cgci_blgsp,
+):
+    """
+    Test that we can submit a valid TSV data file
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    document = MagicMock()
+    document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file["id"] = document.did
+    file["experiments.submitter_id"] = file.pop("experiments")["submitter_id"]
+
+    # convert to TSV (save to file)
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "data/file_tmp.tsv"
+    )
+    with open(file_path, "w") as f:
+        import csv
+        dw = csv.DictWriter(f, sorted(file.keys()), delimiter="\t")
+        dw.writeheader()
+        dw.writerow(file)
+
+    # read the TSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path) # clean up (delete file)
+    assert data
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data, format="tsv"
+    )
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert resp.status_code == 200, resp.data
+
+
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash"
+)
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid"
+)
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index")
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias")
+def test_submit_valid_csv_data_file(
+    create_alias,
+    create_index,
+    get_index_uuid,
+    get_index_hash,
+    client,
+    pg_driver,
+    admin,
+    submitter,
+    cgci_blgsp,
+):
+    """
+    Test that we can submit a valid CSV data file
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    document = MagicMock()
+    document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file["id"] = document.did
+    file["experiments.submitter_id"] = file.pop("experiments")["submitter_id"]
+
+    # convert to CSV (save to file)
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "data/file_tmp.csv"
+    )
+    with open(file_path, "w") as f:
+        import csv
+        dw = csv.DictWriter(f, sorted(file.keys()), delimiter=",")
+        dw.writeheader()
+        dw.writerow(file)
+
+    # read the CSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path) # clean up (delete file)
+    assert data
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data, format="csv"
+    )
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert resp.status_code == 200, resp.data

--- a/tests/integration/datadict/submission/test_upload.py
+++ b/tests/integration/datadict/submission/test_upload.py
@@ -2,6 +2,7 @@
 Test upload entities (mostly data file handling and communication with
 index service).
 """
+import csv
 import json
 import copy
 import os
@@ -141,8 +142,6 @@ def test_tsv_submission_handle_array_type(client):
         os.path.dirname(os.path.realpath(__file__)), "data/experimental_metadata.tsv"
     )
     with open(file_path, "w") as f:
-        import csv
-
         dw = csv.DictWriter(f, sorted(file_data.keys()), delimiter="\t")
         dw.writeheader()
         dw.writerow(file_data)
@@ -151,6 +150,7 @@ def test_tsv_submission_handle_array_type(client):
     doc = None
     with open(file_path, "r") as f:
         doc = f.read()
+    os.remove(file_path) # clean up (delete file)
     assert doc
 
     from sheepdog.utils.transforms import TSVToJSONConverter
@@ -927,7 +927,6 @@ def test_submit_valid_tsv_data_file(
         "data/file_tmp.tsv"
     )
     with open(file_path, "w") as f:
-        import csv
         dw = csv.DictWriter(f, sorted(file.keys()), delimiter="\t")
         dw.writeheader()
         dw.writerow(file)
@@ -1000,7 +999,6 @@ def test_submit_valid_csv_data_file(
         "data/file_tmp.csv"
     )
     with open(file_path, "w") as f:
-        import csv
         dw = csv.DictWriter(f, sorted(file.keys()), delimiter=",")
         dw.writeheader()
         dw.writerow(file)
@@ -1032,6 +1030,143 @@ def test_submit_valid_csv_data_file(
 )
 @patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index")
 @patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias")
+def test_can_submit_data_file_with_asterisk_json(
+    create_alias,
+    create_index,
+    get_index_uuid,
+    get_index_hash,
+    client,
+    pg_driver,
+    admin,
+    submitter,
+    cgci_blgsp,
+):
+    """
+    Test that we can submit a file when some fields have asterisks prepended
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    document = MagicMock()
+    document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file["id"] = document.did
+
+    # insert asterisks before the property names
+    for key in file.keys():
+        file["*{}".format(key)] = file.pop(key)
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+    )
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert_positive_response(resp)
+    entity = assert_single_entity_from_response(resp)
+    assert entity["action"] == "create"
+
+
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash"
+)
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid"
+)
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index")
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias")
+def test_can_submit_data_file_with_asterisk_tsv(
+    create_alias,
+    create_index,
+    get_index_uuid,
+    get_index_hash,
+    client,
+    pg_driver,
+    admin,
+    submitter,
+    cgci_blgsp,
+):
+    """
+    Test that we can submit a file when some fields have asterisks prepended
+    Specifically, "file_size" (and other integer fields) should work with asterisks
+    """
+    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+
+    document = MagicMock()
+    document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
+    get_index_uuid.return_value = document
+    get_index_hash.return_value = document
+
+    # only return the correct document by uuid IF the uuid provided is
+    # the one from above
+    def get_index_by_uuid(uuid):
+        if uuid == document.did:
+            return document
+        else:
+            return None
+
+    get_index_uuid.side_effect = get_index_by_uuid
+
+    file = copy.deepcopy(DEFAULT_METADATA_FILE)
+    file["id"] = document.did
+    file["experiments.submitter_id"] = file.pop("experiments")["submitter_id"]
+
+    # insert asterisks before the property names
+    for key in file.keys():
+        file["*{}".format(key)] = file.pop(key)
+
+    # convert to TSV (save to file)
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "data/file_tmp.tsv"
+    )
+    with open(file_path, "w") as f:
+        dw = csv.DictWriter(f, sorted(file.keys()), delimiter="\t")
+        dw.writeheader()
+        dw.writerow(file)
+
+    # read the TSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path) # clean up (delete file)
+    assert data
+
+    resp = submit_metadata_file(
+        client, pg_driver, admin, submitter, cgci_blgsp, data, format="tsv"
+    )
+
+    # no index or alias creation
+    assert not create_index.called
+    assert not create_alias.called
+
+    # response
+    assert resp.status_code == 200, resp.data
+
+
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_hash"
+)
+@patch(
+    "sheepdog.transactions.upload.sub_entities.FileUploadEntity.get_file_from_index_by_uuid"
+)
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_index")
+@patch("sheepdog.transactions.upload.sub_entities.FileUploadEntity._create_alias")
 def test_link_case_insensitivity(
     create_alias,
     create_index,
@@ -1044,8 +1179,7 @@ def test_link_case_insensitivity(
     cgci_blgsp,
 ):
     """
-    Test submitting the same data again but updating the URL field (should
-    get added to the indexed file in index service).
+    Test that links are case insensitive.
     """
     submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
 


### PR DESCRIPTION
Fix "unable to parse entity" errors when submitting a JSON or TSV (templates use asterisks for required properties)

### Bug Fixes
- fix the parsing of asterisks in properties for TSV and JSON metadata submission

### Improvements
- add tests for TSV and CSV submission
- add tests for TSV and JSON submission with asterisks
