### PR TITLE
PXD-2948: disable timeout for export

### DIFF
--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -6,7 +6,9 @@ chmod-socket = 666
 master = true
 processes = 2
 harakiri-verbose = true
-harakiri = 45
+# No global HARAKIRI, using only user HARAKIRI, because export overwrites it
+# Cannot overwrite global HARAKIRI with user's: https://git.io/fjYuD
+# harakiri = 45
 http-timeout = 45
 socket-timeout = 45
 worker-reload-mercy = 45

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import flask
+
 from fence.jwt.token import generate_signed_access_token
 import pytest
 
@@ -92,3 +94,20 @@ def member(create_user_header):
     project_ids = ["phs000218", "phs000235", "phs000178"]
     project_access = {project: ["_member"] for project in project_ids}
     return create_user_header(MEMBER_USERNAME, project_access)
+
+
+@pytest.yield_fixture
+def client(app):
+    """
+    Overriding the `client` fixture from pytest_flask to fix this bug:
+    https://github.com/pytest-dev/pytest-flask/issues/42
+    """
+    with app.test_client() as client:
+        yield client
+
+    while True:
+        top = flask._request_ctx_stack.top
+        if top is not None and top.preserved:
+            top.pop()
+        else:
+            break


### PR DESCRIPTION
Actually, there were two issues:
* `harakiri` defined in `uwsgi.ini` is a global timeout, it will kill the worker process regardless of `set_user_harakiri`.
* Streaming responses without `stream_with_context()` will call `teardown_request()` hooks (where we cleared user HARAKIRI) immediately after returning the `flask.Response` instance, not after finishing streaming everything as expected.

Upstream bug in testing framework is fixed in pallets/flask#3157.

### Improvements
* Timeout is disabled for export endpoint