### PR TITLE
chore(gdcdictionary)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ psqlgraph==1.2.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
-gdcdictionary==1.1.0
+gdcdictionary==0.2.1
 gdcdatamodel==1.3.12
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
-datamodelutils==0.4.3
+datamodelutils==0.4.4
 psqlgraph==1.2.3
 -e git+https://git@github.com/NCI-GDC/signpost.git@v1.1#egg=signpost
 # required for gdcdatamodel, not required for sheepdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ psqlgraph==1.2.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
-gdcdictionary==0.2.1
+gdcdictionary==1.2.0
 gdcdatamodel==1.3.12
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ psqlgraph==1.2.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
--e git+https://git@github.com/uc-cdis/datadictionary.git@0.2.1#egg=gdcdictionary
+gdcdictionary==1.1.0
 gdcdatamodel==1.3.12
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.5.7#egg=indexclient
 -e git+https://git@github.com/NCI-GDC/python-signpostclient.git@ca686f55772e9a7f839b4506090e7d2bb0de5f15#egg=signpostclient


### PR DESCRIPTION
bump gdcdictionary because error `The 'gdcdictionary~=1.1' distribution was not found and is required by datamodelutils` is thrown when using `datamodelutils` during sheepdog setup

goes with https://github.com/uc-cdis/datamodelutils/pull/9

### Dependency updates
- datamodelutils latest version
