### PR TITLE
bump sqlalchemy from 0.9.9 to 1.3.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,9 +9,6 @@ pytest-flask==0.11.0
 moto==0.4.5
 sphinxcontrib-httpdomain==1.3.0
 
-# force install of sqlalchemy 0.9.9 because indexd installs 1.0.8
-# this new version is not backwards compatible with 0.9.9
-SQLAlchemy==0.9.9
 codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
@@ -23,3 +20,4 @@ authutils==3.1.0
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+-e git+https://github.com/uc-cdis/rbac-client.git@0976a184ac9e70b3d426706ee1685a27fb462802#egg=gen3rbac&subdirectory=python

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,4 +20,3 @@ authutils==3.1.0
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
--e git+https://github.com/uc-cdis/rbac-client.git@0976a184ac9e70b3d426706ee1685a27fb462802#egg=gen3rbac&subdirectory=python

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyYAML==5.1
 requests==2.20.0
 setuptools==30.1.0
 simplejson==3.8.1
-sqlalchemy==0.9.9
+sqlalchemy==1.3.3
 Werkzeug==0.12.2
 xmltodict==0.9.2
 more-itertools==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.36.0
 cryptography==2.3
-dictionaryutils==2.0.4
+dictionaryutils==2.0.7
 envelopes==0.4
 Flask==0.12.4
 flask-cors==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,12 +24,14 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.5
-psqlgraph==1.2.3
+#psqlgraph==1.2.3
 # required for gdcdatamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gdcdictionary==1.2.0
-gdcdatamodel==1.3.12
+gdcdatamodel==1.3.13
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
+
+-e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,8 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.5
-#psqlgraph==1.2.3
+#psqlgraph==2.0.0
+-e git+https://git@github.com/uc-cdis/psqlgraph.git@2.0.0#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
@@ -33,5 +34,3 @@ gdcdictionary==1.2.0
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
 gen3datamodel==2.0.1
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
-
--e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sqlalchemy==1.3.3
 Werkzeug==0.12.2
 xmltodict==0.9.2
 more-itertools==5.0.0
--e git+https://git@github.com/uc-cdis/authutils.git@3.0.1#egg=authutils
+-e git+https://git@github.com/uc-cdis/authutils.git@3.1.0#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.1.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
-#datamodelutils==0.4.6
--e git+https://git@github.com/uc-cdis/datamodelutils.git@fix/migration#egg=datamodelutils
-
+datamodelutils==0.4.7
 psqlgraph==2.0.2
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,9 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.1.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
-datamodelutils==0.4.6
+#datamodelutils==0.4.6
+-e git+https://git@github.com/uc-cdis/datamodelutils.git@fix/migration#egg=datamodelutils
+
 psqlgraph==2.0.2
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pbr==2.0.0
 psycopg2==2.7.3.2
 python-keystoneclient==1.8.1
 PyYAML==5.1
-requests==2.20.0
+requests==2.22.0
 setuptools==30.1.0
 simplejson==3.8.1
 sqlalchemy==1.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,13 +24,12 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.6
-#psqlgraph==2.0.0
--e git+https://git@github.com/uc-cdis/psqlgraph.git@2.0.0#egg=psqlgraph
+psqlgraph==2.0.2
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gdcdictionary==1.2.0
+gen3datamodel==2.0.2
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
-gen3datamodel==2.0.1
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ more-itertools==5.0.0
 cdispyutils==0.2.13
 datamodelutils==0.4.5
 #psqlgraph==1.2.3
-# required for gdcdatamodel, not required for sheepdog
+# required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gdcdictionary==1.2.0
-gdcdatamodel==1.3.13
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
+gen3datamodel==2.0.1
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
 
 -e git+https://git@github.com/uc-cdis/psqlgraph.git@chore/postgresql#egg=psqlgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sqlalchemy==1.3.3
 Werkzeug==0.12.2
 xmltodict==0.9.2
 more-itertools==5.0.0
--e git+https://git@github.com/uc-cdis/authutils.git@3.1.0#egg=authutils
+-e git+https://git@github.com/uc-cdis/authutils.git@3.1.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyYAML==5.1
 requests==2.20.0
 setuptools==30.1.0
 simplejson==3.8.1
-sqlalchemy==1.3.3
+sqlalchemy==1.3.5
 Werkzeug==0.12.2
 xmltodict==0.9.2
 more-itertools==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/authutils.git@3.1.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
-datamodelutils==0.4.5
+datamodelutils==0.4.6
 #psqlgraph==2.0.0
 -e git+https://git@github.com/uc-cdis/psqlgraph.git@2.0.0#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog


### PR DESCRIPTION
The point was to bump sqlalchemy; all these other bumps are to fix the issues that arose from the sqlalchemy bump

### Dependency updates
bump sqlalchemy from 0.9.9 to 1.3.5
bump dictionaryutils from 2.0.4 to 2.0.7
bump psqlgraph to 2.0.2
bump gen3datamodel to 2.0.2
bump indexd from 1.0.8 to 1.1.2
bump authutils to 3.1.1
bump requests to 2.22.0
add rbac-client
bump datamodelutils to 0.4.7

