### PR TITLE
[PXP-3221] Remove fence dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -e git+https://git@github.com/uc-cdis/wool.git#egg=wool; fi
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then psql -c "create database test_userapi" -U postgres; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then userdatamodel-init --db test_userapi; fi
   - pip freeze
   - python bin/setup_test_database.py
   - mkdir -p tests/integration/resources/keys; cd tests/integration/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem; cd -

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,6 +24,3 @@ flasgger==0.9.1
 # these two are required by fence -> cirrus -> google_cloud
 pyasn1-modules==0.0.11
 urllib3==1.23
--e git+https://github.com/uc-cdis/cirrus.git@0.0.0#egg=cirrus-0.0.0
-# required by fence
--e git+https://git@github.com/uc-cdis/userdatamodel.git@1.0.4#egg=userdatamodel

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,6 +21,3 @@ flasgger==0.9.1
 # indexd dependencies
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
-# these two are required by fence -> cirrus -> google_cloud
-pyasn1-modules==0.0.11
-urllib3==1.23

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,6 +25,5 @@ flasgger==0.9.1
 pyasn1-modules==0.0.11
 urllib3==1.23
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.0#egg=cirrus-0.0.0
--e git+https://git@github.com/uc-cdis/fence.git@1.1.1#egg=fence
 # required by fence
 -e git+https://git@github.com/uc-cdis/userdatamodel.git@1.0.4#egg=userdatamodel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def encoded_jwt(iss):
 
         Args:
             private_key (str): private key
-            user (userdatamodel.models.User): user object
+            user (fake userdatamodel.models.User): user object
 
         Return:
             str: JWT containing claims encoded with private key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import flask
 
-from fence.jwt.token import generate_signed_access_token
 import pytest
 
 from sheepdog.auth import ROLES
@@ -38,10 +37,10 @@ def encoded_jwt(iss):
         """
         kid = JWT_KEYPAIR_FILES.keys()[0]
         scopes = ["openid"]
-        token = generate_signed_access_token(
-            kid, private_key, user, 3600, scopes, forced_exp_time=None
+        token = utils.generate_signed_access_token(
+            kid, private_key, user, 3600, scopes, iss=iss, forced_exp_time=None
         )
-        return token
+        return token.token
 
     return encoded_jwt_function
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def encoded_jwt(iss):
 
         Args:
             private_key (str): private key
-            user (fake userdatamodel.models.User): user object
+            user (generic User object): user object
 
         Return:
             str: JWT containing claims encoded with private key
@@ -51,7 +51,7 @@ def create_user_header(encoded_jwt):
         private_key = utils.read_file(
             "./integration/resources/keys/test_private_key.pem"
         )
-        # set up a fake User object which has all the attributes that fence needs
+        # set up a fake User object which has all the attributes needed
         # to generate a token
         user_properties = {
             "id": 1,

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -9,7 +9,6 @@ import requests
 import requests_mock
 from mock import patch
 from flask.testing import make_test_environ_builder
-from fence.jwt.token import generate_signed_access_token
 from psqlgraph import PsqlGraphDriver
 from datamodelutils import models
 from cdispyutils.hmac4 import get_auth

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,9 +20,6 @@ def read_file(filename):
 
 class JWTResult(object):
     """
-    Just copy-pasted from Fence code so that
-    we don't need to import Fence
-
     Just a container for the results necessary to keep track of from generating
     a JWT.
     """
@@ -35,9 +32,6 @@ class JWTResult(object):
 
 def issued_and_expiration_times(seconds_to_expire):
     """
-    Just copy-pasted from Fence code so that
-    we don't need to import Fence
-
     Return the times in unix time that a token is being issued and will be
     expired (the issuing time being now, and the expiration being
     ``seconds_to_expire`` seconds after that). Used for constructing JWTs
@@ -63,15 +57,15 @@ def generate_signed_access_token(
     linked_google_email=None,
 ):
     """
-    Just copy-pasted from Fence code so that
-    we don't need to import Fence
+    Usually, this token is obtained from an outside service.
+    We just simulate that here in order to not import any services.
 
     Generate a JWT access token and output a UTF-8
     string of the encoded JWT signed with the private key.
     Args:
         kid (str): key id of the keypair used to generate token
         private_key (str): RSA private key to sign and encode the JWT with
-        user (fence.models.User): User to generate ID token for
+        user (generic User object): User to generate ID token for
         expires_in (int): seconds until expiration
         scopes (List[str]): oauth scopes for user
     Return:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,14 @@
+import json
 import os
+import time
+import uuid
+
+from authlib.common.encoding import to_unicode
+import jwt
+
+from cdislogging import get_logger
+
+logger = get_logger(__name__, log_level="info")
 
 
 def read_file(filename):
@@ -6,3 +16,115 @@ def read_file(filename):
     root_dir = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(root_dir, filename), "r") as f:
         return f.read()
+
+
+class JWTResult(object):
+    """
+    Just copy-pasted from Fence code so that
+    we don't need to import Fence
+
+    Just a container for the results necessary to keep track of from generating
+    a JWT.
+    """
+
+    def __init__(self, token=None, kid=None, claims=None):
+        self.token = token
+        self.kid = kid
+        self.claims = claims
+
+
+def issued_and_expiration_times(seconds_to_expire):
+    """
+    Just copy-pasted from Fence code so that
+    we don't need to import Fence
+
+    Return the times in unix time that a token is being issued and will be
+    expired (the issuing time being now, and the expiration being
+    ``seconds_to_expire`` seconds after that). Used for constructing JWTs
+    Args:
+        seconds_to_expire (int): lifetime in seconds
+    Return:
+        Tuple[int, int]: (issued, expired) times in unix time
+    """
+    iat = int(time.time())
+    exp = iat + int(seconds_to_expire)
+    return (iat, exp)
+
+
+def generate_signed_access_token(
+    kid,
+    private_key,
+    user,
+    expires_in,
+    scopes,
+    iss=None,
+    forced_exp_time=None,
+    client_id=None,
+    linked_google_email=None,
+):
+    """
+    Just copy-pasted from Fence code so that
+    we don't need to import Fence
+
+    Generate a JWT access token and output a UTF-8
+    string of the encoded JWT signed with the private key.
+    Args:
+        kid (str): key id of the keypair used to generate token
+        private_key (str): RSA private key to sign and encode the JWT with
+        user (fence.models.User): User to generate ID token for
+        expires_in (int): seconds until expiration
+        scopes (List[str]): oauth scopes for user
+    Return:
+        str: encoded JWT access token signed with ``private_key``
+    """
+    headers = {"kid": kid}
+    iat, exp = issued_and_expiration_times(expires_in)
+    # force exp time if provided
+    exp = forced_exp_time or exp
+    sub = str(user.id)
+    jti = str(uuid.uuid4())
+    if not iss:
+        try:
+            iss = config.get("BASE_URL")
+        except RuntimeError:
+            raise ValueError(
+                "must provide value for `iss` (issuer) field if"
+                " running outside of flask application"
+            )
+
+    claims = {
+        "pur": "access",
+        "aud": scopes,
+        "sub": sub,
+        "iss": iss,
+        "iat": iat,
+        "exp": exp,
+        "jti": jti,
+        "context": {
+            "user": {
+                "name": user.username,
+                "is_admin": user.is_admin,
+                "projects": dict(user.project_access),
+                "google": {"proxy_group": user.google_proxy_group_id},
+            }
+        },
+        "azp": client_id or "",
+    }
+
+    # only add google linkage information if provided
+    if linked_google_email:
+        claims["context"]["user"]["google"][
+            "linked_google_account"
+        ] = linked_google_email
+
+    logger.info("issuing JWT access token with id [{}] to [{}]".format(jti, sub))
+    logger.debug("issuing JWT access token\n" + json.dumps(claims, indent=4))
+
+    token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
+    token = to_unicode(token, "UTF-8")
+
+    # Browser may clip cookies larger than 4096 bytes
+    if len(token) > 4096:
+        raise JWTSizeError("JWT exceeded 4096 bytes")
+
+    return JWTResult(token=token, kid=kid, claims=claims)


### PR DESCRIPTION
Remove cirrus, fence, and userdatamodel from dev-requirements.txt; just inline the code for token generation (= copy paste a bunch of code from fence/fence/jwt/token to sheepdog/tests/utils, but at least fence is no longer a dependency) 

### Dependency updates
- Remove cirrus from dev-requirements
- Remove fence from dev-requirements
- Remove userdatamodel from dev-requirements
