### PR TITLE
add allow_failures in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
   - "2.7"
   - "3.6"
 
+matrix:
+  allow_failures:
+    - python: "3.6"
+
 sudo: false
 
 cache:
@@ -42,17 +46,17 @@ install:
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then psql -c "create database test_userapi" -U postgres; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then userdatamodel-init --db test_userapi; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip freeze; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then python bin/setup_test_database.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then mkdir -p tests/integration/resources/keys; cd tests/integration/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem; cd -; fi
+  - pip freeze
+  - python bin/setup_test_database.py
+  - mkdir -p tests/integration/resources/keys; cd tests/integration/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem; cd -
 
 # commands to run tests
 script:
   # datadict and datadictwithobjid tests must run separately to allow
   # loading different datamodels
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadict; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadictwithobjid; fi
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then py.test -vv --cov=sheepdog --cov-report xml tests/unit; fi
+- py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadict
+- py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadictwithobjid
+- py.test -vv --cov=sheepdog --cov-report xml tests/unit
 
 after_script:
 - python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
testing this out 

Instead of `if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then *test the things*; fi` just tell Travis to allow 3.6 failure. Then there are no false positives 