### PR TITLE
Fix issue using abs path

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -624,10 +624,9 @@ class FileUploadEntity(UploadEntity):
 
         # update acl and uploader fields in indexd
         data = json.dumps({"acl": self.transaction.get_phsids(), "uploader": None})
-        url = "/index/" + self.object_id
         try:
             self.transaction.signpost._put(
-                url,
+                "index", self.object_id,
                 headers={"content-type": "application/json"},
                 data=data,
                 params={"rev": self.file_by_uuid.rev},


### PR DESCRIPTION
`IndexClient` is using `urljoin(base_url, '/'.join(parts))`.

### Bug Fixes
- Fixed a bug in Indexd API calling when base_url has subpath