### PR TITLE
bump gdcdictionary to gen3dictionary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ psqlgraph==2.0.2
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
-gdcdictionary==1.2.0
+gen3dictionary==2.0.0
 gen3datamodel==2.0.2
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient


### PR DESCRIPTION


### Dependency updates
- bump gdcdictionary to gen3dictionary 2.0.0

