### PR TITLE
fix(data-upload-authz): update authz field and fix revision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ flask-cors==3.0.3
 Flask-SQLAlchemy-Session==1.1
 fuzzywuzzy==0.6.1
 graphene==2.0.1
+rx==1.6.1
 jsonschema==2.5.1
 lxml==3.8.0
 pbr==2.0.0

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -624,16 +624,10 @@ class FileUploadEntity(UploadEntity):
             return
 
         # update acl and uploader fields in indexd
-        data = json.dumps({"acl": self.transaction.get_phsids(), "uploader": None})
+        self.file_by_uuid.acl = self.transaction.get_phsids()
+        self.file_by_uuid.uploader = None
         try:
-            self.transaction.index_client._put(
-                "index", self.object_id,
-                headers={"content-type": "application/json"},
-                data=data,
-                params={"rev": self.file_by_uuid.rev},
-                auth=self.transaction.index_client.auth,
-            )
-            self.file_by_uuid._load() # to sync new rev from server
+            self.file_by_uuid.patch()
         except requests.HTTPError as e:
             self.record_error(
                 "Failed to update acl and uploader fields in indexd: {}".format(

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -233,6 +233,28 @@ class FileUploadEntity(UploadEntity):
                 if self.should_update_acl_uploader:
                     self._update_acl_uploader_for_file()
 
+                    # Temporary fix to update authz field in index record
+                    # in the data upload flow case,
+                    # while we don't have a way to do it properly (i.e. with permissions checks)
+                    document = self.file_by_uuid or self.file_by_hash
+                    namespace = flask.current_app.config.get("AUTH_NAMESPACE", "")
+                    authz = [
+                        "{}/programs/{}/projects/{}"
+                        .format(namespace, self.transaction.program, self.transaction.project)
+                    ]
+                    use_consent_codes = (
+                        dictionary.schema.get(self.entity_type, {})
+                        .get("properties", {})
+                        .get("consent_codes")
+                    )
+                    if use_consent_codes:
+                        consent_codes = self.node._props.get("consent_codes")
+                        if consent_codes:
+                            authz.extend("/consents/" + code for code in consent_codes)
+                    document.authz = authz
+                    document.patch()
+                    # End temporary fix
+
                 # Check if the category for the node is data_file or
                 # metadata_file, in which case, register a UUID and alias in
                 # the index service.
@@ -611,6 +633,7 @@ class FileUploadEntity(UploadEntity):
                 params={"rev": self.file_by_uuid.rev},
                 auth=self.transaction.index_client.auth,
             )
+            self.file_by_uuid._load() # to sync new rev from server
         except requests.HTTPError as e:
             self.record_error(
                 "Failed to update acl and uploader fields in indexd: {}".format(


### PR DESCRIPTION
### Bug Fixes
Update authz field in blank indexd record in data upload flow
Sync new revision from indexd server after _update_acl_uploader_for_file

### Dependency updates
temporarily pin rx==1.6.1 until sheepdog is python 3
