### PR TITLE
fix(run.py): mock arborist calls

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ flasgger==0.9.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@1.1.3#egg=indexd
 # indexd dependencies
-authutils==3.1.0
+authutils==3.1.1
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+authutils==3.1.1
 boto==2.36.0
 cryptography==2.3
 dictionaryutils==2.0.7
@@ -22,7 +23,6 @@ sqlalchemy==1.3.5
 Werkzeug==0.12.2
 xmltodict==0.9.2
 more-itertools==5.0.0
--e git+https://git@github.com/uc-cdis/authutils.git@3.1.1#egg=authutils
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.7


### PR DESCRIPTION
Patch `run.py` so that gen3authz requests are mocked when we run sheepdog locally
