### PR TITLE
chore(flask): flask 1.1.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
-pytest==3.6.3
+pytest>=4.6.5,<5.0.0
 pytest-cov==2.5.1
 requests_mock==1.4.0
 httmock==1.2.3
 lockfile==0.10.2
 coverage==3.7.1
 mock==1.0.1
-pytest-flask==0.11.0
+pytest-flask==0.15.0
 moto==0.4.5
 sphinxcontrib-httpdomain==1.3.0
 
@@ -14,6 +14,7 @@ Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
+# TODO: when sheepdog is python 3, update to latest indexd
 -e git+https://git@github.com/uc-cdis/indexd.git@1.1.3#egg=indexd
 # indexd dependencies
 authutils==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto==2.36.0
 cryptography==2.3
 dictionaryutils==2.0.7
 envelopes==0.4
-Flask==0.12.4
+Flask==1.1.1
 flask-cors==3.0.3
 Flask-SQLAlchemy-Session==1.1
 fuzzywuzzy==0.6.1
@@ -20,7 +20,7 @@ requests==2.22.0
 setuptools==30.1.0
 simplejson==3.8.1
 sqlalchemy==1.3.5
-Werkzeug==0.12.2
+Werkzeug==0.16.0
 xmltodict==0.9.2
 more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -410,7 +410,7 @@ def export_entities(program, project):
     project_id = "{}-{}".format(program, project)
     file_format = kwargs.get("file_format") or "tsv"
 
-    mimetype = "application/octet-stream"
+    mimetype = "application/json" if file_format.lower() == "json" else "application/octet-stream"
     if not kwargs.get("ids"):
         if not node_label:
             raise UserError("expected either `ids` or `node_label` parameter")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def create_user_header(encoded_jwt):
         # to generate a token
         user_properties = {
             "id": 1,
-            "username": "submitter",
+            "username": username,
             "is_admin": False,
             "policies": [],
             "google_proxy_group_id": None,

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -42,7 +42,6 @@ def get_parent(path):
 
 PATH_TO_SCHEMA_DIR = get_parent(os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir))) + '/datadict/schemas'
 
-@pytest.fixture(scope='session')
 def pg_config():
     test_host = 'localhost'
     test_user = 'test'

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -705,7 +705,7 @@ def test_export_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
         path,
         headers=submitter)
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
     assert data[0]['id'] == case_id
 
 

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -36,7 +36,6 @@ PATH_TO_SCHEMA_DIR = (
 )
 
 
-@pytest.fixture(scope="session")
 def pg_config():
     test_host = "localhost"
     test_user = "test"

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -596,8 +596,8 @@ def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter,
 
     print r.json
     data = r.json
+    assert data and len(data) == 1
     object_id = data[0]['object_id']
-    assert len(data) == 1
     assert object_id
 
     assert sur_entity, 'No submitted_unaligned_reads entity created'
@@ -620,7 +620,7 @@ def test_export_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
         path,
         headers=submitter)
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
     assert data[0]['id'] == case_id
 
 

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -120,7 +120,7 @@ def test_data_file_not_indexed(
     r = client.get(path, headers=submitter)
 
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
     assert did == None
 
 
@@ -241,7 +241,7 @@ def test_data_file_already_indexed(
     r = client.get(path, headers=submitter)
 
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
     assert data[0]["object_id"] == document.did
     assert data[0]["id"] != document.did
 
@@ -587,7 +587,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     r = client.get(path, headers=submitter)
 
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
     assert data[0]["object_id"] == file["object_id"]
 
     # check that the acl and uploader fields have been updated in indexd
@@ -921,7 +921,7 @@ def test_create_file_no_required_index(
     r = client.get(path, headers=submitter)
 
     data = r.json
-    assert len(data) == 1
+    assert data and len(data) == 1
 
 
 @patch(


### PR DESCRIPTION
Bump flask to the latest version
also bump pytest to 4.6.5 (latest version that supports python 2) and pytest-flask to 0.15.0 (latest version)

### Dependency updates
- Flask 1.1.1, Werkzeug 0.16.0
