### PR TITLE
fix(AUTH_SUBMISSION_LIST): import authutils validate_request

### DIFF
--- a/sheepdog/auth/__init__.py
+++ b/sheepdog/auth/__init__.py
@@ -19,6 +19,11 @@ from sheepdog.errors import AuthNError, AuthZError
 
 logger = get_logger(__name__)
 
+try:
+    from authutils.token.validate import validate_request
+except ImportError:
+    logger.warning("Unable to import authutils validate_request. Sheepdog will error if config AUTH_SUBMISSION_LIST is set to True (note that it is True by default)")
+
 
 def get_jwt_from_header():
     jwt = None


### PR DESCRIPTION
When `AUTH_SUBMISSION_LIST` config is True (which is the default value), sheepdog makes calls to function `validate_request`. This function used to be imported but this piece of code was removed by mistake in #298 

### Bug Fixes
- Fix `validate_request` bug when `AUTH_SUBMISSION_LIST` config is not set or set to True