### PR TITLE
PXP-3408 Update Sheepdog to Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ group: deprecated-2017Q2
 language: python
 
 python:
-  - "2.7"
   - "3.6"
-
-matrix:
-  allow_failures:
-    - python: "2.7"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ script:
   # datadict and datadictwithobjid tests must run separately to allow
   # loading different datamodels
 - py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadict
-- py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadictwithobjid
-- py.test -vv --cov=sheepdog --cov-report xml tests/unit
+- py.test -vv --cov=sheepdog --cov-report xml --cov-append tests/integration/datadictwithobjid
+- py.test -vv --cov=sheepdog --cov-report xml --cov-append tests/unit
 
 after_script:
 - python-codacy-coverage -r coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 matrix:
   allow_failures:
-    - python: "3.6"
+    - python: "2.7"
 
 sudo: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run -v /path/to/wsgi.py:/var/www/sheepdog/wsgi.py --name=sheepdog -p 81:80 sheepdog
 # To check running container: docker exec -it sheepdog /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.0.0
+FROM quay.io/cdis/python-nginx:pybase3-1.1.0
 
 RUN apk update \
     && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,27 @@
 
 FROM quay.io/cdis/python-nginx:pybase3-1.0.0
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN mkdir /var/www/sheepdog \
-    && chown www-data /var/www/sheepdog
+RUN apk update \
+    && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \
+    && apk add linux-headers musl-dev gcc libxml2-dev libxslt-dev\
+    && apk add curl bash git vim
 
 COPY . /sheepdog
 COPY ./deployment/uwsgi/uwsgi.ini /etc/uwsgi/uwsgi.ini
 WORKDIR /sheepdog
 
-RUN python -m pip install -r requirements.txt \
-    && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >sheepdog/version_data.py \
-    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --upgrade setuptools \
+    && pip --version \
+    && pip install -r requirements.txt
+
+RUN mkdir -p /var/www/sheepdog \
+    && chown nginx /var/www/sheepdog
 
 EXPOSE 80
+
+RUN COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >sheepdog/version_data.py \
+    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py
 
 WORKDIR /var/www/sheepdog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /sheepdog
 RUN python -m pip install --upgrade pip \
     && python -m pip install --upgrade setuptools \
     && pip --version \
-    && pip install -r requirements.txt
+    && python -m pip install -r requirements.txt
 
 RUN mkdir -p /var/www/sheepdog \
     && mkdir /run/ngnix/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run -v /path/to/wsgi.py:/var/www/sheepdog/wsgi.py --name=sheepdog -p 81:80 sheepdog
-# To check running container: docker exec -it sheepdog /bin/bash 
+# To check running container: docker exec -it sheepdog /bin/bash
 
-FROM quay.io/cdis/py27base:pybase2-1.0.2
+FROM quay.io/cdis/python-nginx:pybase3-1.0.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -14,9 +14,9 @@ WORKDIR /sheepdog
 
 RUN python -m pip install -r requirements.txt \
     && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >sheepdog/version_data.py \
-    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py 
+    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py
 
-EXPOSE 80 
+EXPOSE 80
 
 WORKDIR /var/www/sheepdog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN mkdir -p /var/www/sheepdog \
 EXPOSE 80
 
 RUN COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" >sheepdog/version_data.py \
-    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py
+    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >>sheepdog/version_data.py \
+    && python setup.py install
 
 WORKDIR /var/www/sheepdog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/cdis/python-nginx:pybase3-1.0.0
 
 RUN apk update \
     && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \
-    && apk add linux-headers musl-dev gcc libxml2-dev libxslt-dev\
+    && apk add linux-headers musl-dev gcc libxml2-dev \
     && apk add curl bash git vim
 
 COPY . /sheepdog
@@ -18,6 +18,7 @@ RUN python -m pip install --upgrade pip \
     && pip install -r requirements.txt
 
 RUN mkdir -p /var/www/sheepdog \
+    && mkdir /run/ngnix/ \
     && chown nginx /var/www/sheepdog
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /sheepdog
 RUN python -m pip install --upgrade pip \
     && python -m pip install --upgrade setuptools \
     && pip --version \
-    && python -m pip install -r requirements.txt
+    && pip install -r requirements.txt
 
 RUN mkdir -p /var/www/sheepdog \
     && mkdir /run/ngnix/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/cdis/python-nginx:pybase3-1.0.0
 
 RUN apk update \
     && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \
-    && apk add linux-headers musl-dev gcc libxml2-dev \
+    && apk add linux-headers musl-dev gcc libxml2-dev libxslt-dev \
     && apk add curl bash git vim
 
 COPY . /sheepdog

--- a/bin/setup_psqlgraph.py
+++ b/bin/setup_psqlgraph.py
@@ -21,7 +21,7 @@ def try_drop_test_data(user, database, root_user='postgres', host='', root_passw
     try:
         create_stmt = 'DROP DATABASE "{database}"'.format(database=database)
         conn.execute(create_stmt)
-    except Exception, msg:
+    except Exception as msg:
         logging.warning("Unable to drop test data:" + str(msg))
 
     conn.close()
@@ -51,7 +51,7 @@ def setup_database(user, password, database, root_user='postgres',
     create_stmt = 'CREATE DATABASE "{database}"'.format(database=database)
     try:
         conn.execute(create_stmt)
-    except Exception, msg:
+    except Exception as msg:
         logging.warn('Unable to create database: {}'.format(msg))
 
     if not no_user:
@@ -59,7 +59,7 @@ def setup_database(user, password, database, root_user='postgres',
             user_stmt = "CREATE USER {user} WITH PASSWORD '{password}'".format(
                 user=user, password=password)
             conn.execute(user_stmt)
-        except Exception, msg:
+        except Exception as msg:
             logging.warn("Unable to add user:" + str(msg))
         # User may already exist - GRANT privs on new db
         try:
@@ -67,7 +67,7 @@ def setup_database(user, password, database, root_user='postgres',
                         ''.format(database=database, password=password)
             conn.execute(perm_stmt)
             conn.execute("commit")
-        except Exception, msg:
+        except Exception as msg:
             logging.warn("Unable to GRANT privs to user:" + str(msg))
     conn.close()
 

--- a/bin/setup_psqlgraph.py
+++ b/bin/setup_psqlgraph.py
@@ -5,13 +5,13 @@ from gdcdatamodel.models import *
 from psqlgraph import create_all, Node, Edge
 
 
-def try_drop_test_data(user, database, root_user='postgres', host='', root_password='' ):
-    print('Dropping old test data')
-    connect_str="postgres://{user}@{host}/postgres".format(
-        user=root_user, host=host)
+def try_drop_test_data(user, database, root_user="postgres", host="", root_password=""):
+    print("Dropping old test data")
+    connect_str = "postgres://{user}@{host}/postgres".format(user=root_user, host=host)
     if root_password:
-      connect_str="postgres://{user}:{password}@{host}/postgres".format(
-          user=root_user, password=root_password, host=host)
+        connect_str = "postgres://{user}:{password}@{host}/postgres".format(
+            user=root_user, password=root_password, host=host
+        )
 
     engine = create_engine(connect_str)
 
@@ -27,22 +27,29 @@ def try_drop_test_data(user, database, root_user='postgres', host='', root_passw
     conn.close()
 
 
-def setup_database(user, password, database, root_user='postgres',
-                   host='', no_drop=False, no_user=False, root_password=''
-                  ):
+def setup_database(
+    user,
+    password,
+    database,
+    root_user="postgres",
+    host="",
+    no_drop=False,
+    no_user=False,
+    root_password="",
+):
     """
     setup the user and database
     """
-    print('Setting up test database')
+    print("Setting up test database")
 
     if not no_drop:
         try_drop_test_data(user, database, root_user, host, root_password)
 
-    connect_str="postgres://{user}@{host}/postgres".format(
-        user=root_user, host=host)
+    connect_str = "postgres://{user}@{host}/postgres".format(user=root_user, host=host)
     if password:
-      connect_str="postgres://{user}:{password}@{host}/postgres".format(
-          user=root_user, password=root_password, host=host)
+        connect_str = "postgres://{user}:{password}@{host}/postgres".format(
+            user=root_user, password=root_password, host=host
+        )
 
     engine = create_engine(connect_str)
     conn = engine.connect()
@@ -52,19 +59,22 @@ def setup_database(user, password, database, root_user='postgres',
     try:
         conn.execute(create_stmt)
     except Exception as msg:
-        logging.warn('Unable to create database: {}'.format(msg))
+        logging.warn("Unable to create database: {}".format(msg))
 
     if not no_user:
         try:
             user_stmt = "CREATE USER {user} WITH PASSWORD '{password}'".format(
-                user=user, password=password)
+                user=user, password=password
+            )
             conn.execute(user_stmt)
         except Exception as msg:
             logging.warn("Unable to add user:" + str(msg))
         # User may already exist - GRANT privs on new db
         try:
-            perm_stmt = 'GRANT ALL PRIVILEGES ON DATABASE {database} to {password}'\
-                        ''.format(database=database, password=password)
+            perm_stmt = (
+                "GRANT ALL PRIVILEGES ON DATABASE {database} to {password}"
+                "".format(database=database, password=password)
+            )
             conn.execute(perm_stmt)
             conn.execute("commit")
         except Exception as msg:
@@ -76,57 +86,80 @@ def create_tables(host, user, password, database):
     """
     create a table
     """
-    print('Creating tables in test database')
+    print("Creating tables in test database")
 
-    engine = create_engine("postgres://{user}:{pwd}@{host}/{db}".format(
-        user=user, host=host, pwd=password, db=database))
+    engine = create_engine(
+        "postgres://{user}:{pwd}@{host}/{db}".format(
+            user=user, host=host, pwd=password, db=database
+        )
+    )
     create_all(engine)
     versioned_nodes.Base.metadata.create_all(engine)
 
 
 def create_indexes(host, user, password, database):
-    print('Creating indexes')
-    engine = create_engine("postgres://{user}:{pwd}@{host}/{db}".format(
-        user=user, host=host, pwd=password, db=database))
+    print("Creating indexes")
+    engine = create_engine(
+        "postgres://{user}:{pwd}@{host}/{db}".format(
+            user=user, host=host, pwd=password, db=database
+        )
+    )
     index = lambda t, c: ["CREATE INDEX ON {} ({})".format(t, x) for x in c]
     for scls in Node.get_subclasses():
         tablename = scls.__tablename__
-        map(engine.execute, index(
-            tablename, [
-                'node_id',
-            ]))
-        map(engine.execute, [
-            "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
-            "CREATE INDEX ON {} USING gin (_props)".format(tablename),
-            "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
-        ])
+        map(engine.execute, index(tablename, ["node_id",]))
+        map(
+            engine.execute,
+            [
+                "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
+                "CREATE INDEX ON {} USING gin (_props)".format(tablename),
+                "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
+            ],
+        )
     for scls in Edge.get_subclasses():
-        map(engine.execute, index(
-            scls.__tablename__, [
-                'src_id',
-                'dst_id',
-                'dst_id, src_id',
-            ]))
+        map(
+            engine.execute,
+            index(scls.__tablename__, ["src_id", "dst_id", "dst_id, src_id",]),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--host", type=str, action="store",
-                        default='localhost', help="psql-server host")
-    parser.add_argument("--user", type=str, action="store",
-                        default='test', help="psql test user")
-    parser.add_argument("--password", type=str, action="store",
-                        default='test', help="psql test password")
-    parser.add_argument("--database", type=str, action="store",
-                        default='sheepdog_automated_test', help="psql test database")
-    parser.add_argument("--no-drop", action="store_true",
-                        default=False, help="do not drop any data")
-    parser.add_argument("--no-user", action="store_true",
-                        default=False, help="do not create user")
+    parser.add_argument(
+        "--host", type=str, action="store", default="localhost", help="psql-server host"
+    )
+    parser.add_argument(
+        "--user", type=str, action="store", default="test", help="psql test user"
+    )
+    parser.add_argument(
+        "--password",
+        type=str,
+        action="store",
+        default="test",
+        help="psql test password",
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        action="store",
+        default="sheepdog_automated_test",
+        help="psql test database",
+    )
+    parser.add_argument(
+        "--no-drop", action="store_true", default=False, help="do not drop any data"
+    )
+    parser.add_argument(
+        "--no-user", action="store_true", default=False, help="do not create user"
+    )
 
     args = parser.parse_args()
-    setup_database(args.user, args.password, args.database,
-                   no_drop=args.no_drop, no_user=args.no_user)
+    setup_database(
+        args.user,
+        args.password,
+        args.database,
+        no_drop=args.no_drop,
+        no_user=args.no_user,
+    )
     create_tables(args.host, args.user, args.password, args.database)
     create_indexes(args.host, args.user, args.password, args.database)

--- a/bin/setup_psqlgraph.py
+++ b/bin/setup_psqlgraph.py
@@ -107,20 +107,20 @@ def create_indexes(host, user, password, database):
     index = lambda t, c: ["CREATE INDEX ON {} ({})".format(t, x) for x in c]
     for scls in Node.get_subclasses():
         tablename = scls.__tablename__
-        map(engine.execute, index(tablename, ["node_id",]))
-        map(
+        list(map(engine.execute, index(tablename, ["node_id",])))
+        list(map(
             engine.execute,
             [
                 "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
                 "CREATE INDEX ON {} USING gin (_props)".format(tablename),
                 "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
             ],
-        )
+        ))
     for scls in Edge.get_subclasses():
-        map(
+        list(map(
             engine.execute,
             index(scls.__tablename__, ["src_id", "dst_id", "dst_id, src_id",]),
-        )
+        ))
 
 
 if __name__ == "__main__":

--- a/bin/setup_psqlgraph.py
+++ b/bin/setup_psqlgraph.py
@@ -108,19 +108,23 @@ def create_indexes(host, user, password, database):
     for scls in Node.get_subclasses():
         tablename = scls.__tablename__
         list(map(engine.execute, index(tablename, ["node_id",])))
-        list(map(
-            engine.execute,
-            [
-                "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
-                "CREATE INDEX ON {} USING gin (_props)".format(tablename),
-                "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
-            ],
-        ))
+        list(
+            map(
+                engine.execute,
+                [
+                    "CREATE INDEX ON {} USING gin (_sysan)".format(tablename),
+                    "CREATE INDEX ON {} USING gin (_props)".format(tablename),
+                    "CREATE INDEX ON {} USING gin (_sysan, _props)".format(tablename),
+                ],
+            )
+        )
     for scls in Edge.get_subclasses():
-        list(map(
-            engine.execute,
-            index(scls.__tablename__, ["src_id", "dst_id", "dst_id, src_id",]),
-        ))
+        list(
+            map(
+                engine.execute,
+                index(scls.__tablename__, ["src_id", "dst_id", "dst_id, src_id",]),
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/build_openapi.py
+++ b/build_openapi.py
@@ -40,13 +40,13 @@ def translate_to_swag(doc, subs):
     spec = {
         "description": doc.get("Description", ""),
         "summary": summary,
-        "tags": map(lambda i: i.description, doc.get("Tags", [])),
+        "tags": [i.description for i in doc.get("Tags", [])],
     }
 
     # Responses and status codes
     resps = doc.get("Responses")
     spec["responses"] = {}
-    for code, props in resps.iteritems():
+    for code, props in resps.items():
         spec["responses"][code] = {"description": props.description}
         if props.type:
             ref = "#/definitions/{}".format(props.type)
@@ -63,7 +63,7 @@ def translate_to_swag(doc, subs):
             "description": props.description,
             "required": True,
         }
-        for name, props in args.iteritems()
+        for name, props in args.items()
         if props.name != "body"
     ]
 
@@ -76,7 +76,7 @@ def translate_to_swag(doc, subs):
                 "description": props.description,
                 "schema": {"$ref": "#/definitions/{}".format(props.type)},
             }
-            for name, props in args.iteritems()
+            for name, props in args.items()
             if props.name == "body"
         ]
     )
@@ -91,7 +91,7 @@ def translate_to_swag(doc, subs):
                 "type": swagger_types.get(props.type, props.type),
                 "description": props.description,
             }
-            for name, props in args.iteritems()
+            for name, props in args.items()
         ]
     )
 
@@ -105,13 +105,13 @@ def translate_to_swag(doc, subs):
                 "type": swagger_types.get(props.type, props.type),
                 "description": props.description,
             }
-            for name, props in args.iteritems()
+            for name, props in args.items()
         ]
     )
 
     # handle substitutions
     for p in spec["parameters"]:
-        for k, v in subs.iteritems():
+        for k, v in subs.items():
             p["description"] = p["description"].replace(k, v)
 
     return spec
@@ -132,7 +132,7 @@ def parse_sphinx_substitutions():
     subs = {}
     try:
         with open(file_name, "r") as f:
-            lines = map(lambda i: i.strip(), f.readlines())
+            lines = [i.strip() for i in f.readlines()]
             indexes = [i for i, s in enumerate(lines) if "replace::" in s]
             for i, start in enumerate(indexes):
                 end = indexes[i + 1] if i < len(indexes) - 1 else len(lines)
@@ -140,7 +140,7 @@ def parse_sphinx_substitutions():
                 description = " ".join(lines[start + 1 : end])
                 subs[name] = description.strip()
     except IOError:
-        print("Substitution file {} not found".format(file_name))
+        print(("Substitution file {} not found".format(file_name)))
     return subs
 
 
@@ -169,11 +169,11 @@ def build_swag_doc():
 
         docstring = route["view_func"].__doc__
         if not docstring:
-            print(
+            print((
                 "This endpoint is not documented: {}".format(
                     route["view_func"].__name__
                 )
-            )
+            ))
 
         parsed_doc = Docstring.from_string(docstring)
         spec = translate_to_swag(parsed_doc.sections, subs)

--- a/build_openapi.py
+++ b/build_openapi.py
@@ -140,7 +140,7 @@ def parse_sphinx_substitutions():
                 description = " ".join(lines[start + 1 : end])
                 subs[name] = description.strip()
     except IOError:
-        print(("Substitution file {} not found".format(file_name)))
+        print("Substitution file {} not found".format(file_name))
     return subs
 
 
@@ -169,11 +169,11 @@ def build_swag_doc():
 
         docstring = route["view_func"].__doc__
         if not docstring:
-            print((
+            print(
                 "This endpoint is not documented: {}".format(
                     route["view_func"].__name__
                 )
-            ))
+            )
 
         parsed_doc = Docstring.from_string(docstring)
         spec = translate_to_swag(parsed_doc.sections, subs)

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -2,9 +2,11 @@
 protocol = uwsgi
 socket = /var/run/gen3/uwsgi.sock
 buffer-size = 32768
+uid = nginx
+gid = nginx
+chown-socket = nginx:nginx
 chmod-socket = 666
 master = true
-processes = 2
 harakiri-verbose = true
 # No global HARAKIRI, using only user HARAKIRI, because export overwrites it
 # Cannot overwrite global HARAKIRI with user's: https://git.io/fjYuD
@@ -16,13 +18,9 @@ reload-mercy = 45
 mule-reload-mercy = 45
 disable-logging = true
 wsgi-file=/var/www/sheepdog/wsgi.py
-plugins = python
+plugins = python3
 vacuum = true
-uid = www-data
-gid = www-data
-pythonpath = /var/www/sheepdog/
 pythonpath = /sheepdog/
-pythonpath = /usr/local/lib/python3.6/site-packages/
 # Initialize application in worker processes, not master. This prevents the
 # workers from all trying to open the same database connections at startup.
 lazy = true

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -22,7 +22,7 @@ uid = www-data
 gid = www-data
 pythonpath = /var/www/sheepdog/
 pythonpath = /sheepdog/
-pythonpath = /usr/local/lib/python2.7/dist-packages/
+pythonpath = /usr/local/lib/python3.6/site-packages/
 # Initialize application in worker processes, not master. This prevents the
 # workers from all trying to open the same database connections at startup.
 lazy = true

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -21,6 +21,7 @@ wsgi-file=/var/www/sheepdog/wsgi.py
 plugins = python3
 vacuum = true
 pythonpath = /sheepdog/
+pythonpath = /usr/local/lib/python3.6/site-packages/
 # Initialize application in worker processes, not master. This prevents the
 # workers from all trying to open the same database connections at startup.
 lazy = true

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -20,6 +20,7 @@ disable-logging = true
 wsgi-file=/var/www/sheepdog/wsgi.py
 plugins = python3
 vacuum = true
+pythonpath = /var/www/sheepdog/
 pythonpath = /sheepdog/
 pythonpath = /usr/local/lib/python3.6/site-packages/
 # Initialize application in worker processes, not master. This prevents the

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,11 +13,10 @@ codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
+#TODO: update this one
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
-# TODO: when sheepdog is python 3, update to latest indexd
--e git+https://git@github.com/uc-cdis/indexd.git@1.1.3#egg=indexd
+-e git+https://git@github.com/uc-cdis/indexd.git@2.1.0#egg=indexd
 # indexd dependencies
 authutils==3.1.1
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
--e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest
--e git+https://git@github.com/uc-cdis/indexd.git@2.1.0#egg=indexd
+-e git+https://git@github.com/uc-cdis/indexd.git@2.3.0#egg=indexd
 # indexd dependencies
 authutils==3.1.1
 gen3rbac==0.1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,3 +20,4 @@ flasgger==0.9.1
 authutils==3.1.1
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
+-e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ pytest-cov==2.5.1
 requests_mock==1.4.0
 httmock==1.2.3
 lockfile==0.10.2
-coverage==3.7.1
+coverage==4.0.0
 mock==1.0.1
 pytest-flask==0.15.0
 moto==0.4.5

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@ codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
--e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
+-e git+https://git@github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@2.1.0#egg=indexd
 # indexd dependencies
 authutils==3.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,11 +13,10 @@ codacy-coverage
 Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
-#TODO: update this one
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@0.0.1#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@2.1.0#egg=indexd
 # indexd dependencies
 authutils==3.1.1
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
--e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
+-e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,9 +53,9 @@ source_suffix = ".rst"
 master_doc = "contents"
 
 # General information about the project.
-project = u"sheepdog"
-copyright = u"2017, Center for Data Intensive Science"
-author = u"Center for Data Intensive Science"
+project = "sheepdog"
+copyright = "2017, Center for Data Intensive Science"
+author = "Center for Data Intensive Science"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -238,8 +238,8 @@ latex_documents = [
     (
         master_doc,
         "sheepdog.tex",
-        u"sheepdog Documentation",
-        u"Center for Data Intensive Science",
+        "sheepdog Documentation",
+        "Center for Data Intensive Science",
         "manual",
     )
 ]
@@ -269,7 +269,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "sheepdog", u"sheepdog Documentation", [author], 1)]
+man_pages = [(master_doc, "sheepdog", "sheepdog Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -284,7 +284,7 @@ texinfo_documents = [
     (
         master_doc,
         "sheepdog",
-        u"sheepdog Documentation",
+        "sheepdog Documentation",
         author,
         "sheepdog",
         "One line description of project.",

--- a/openapi/docstring_parser.py
+++ b/openapi/docstring_parser.py
@@ -74,7 +74,7 @@ class Docstring(object):
         except ValueError:
             pass
 
-        args = list(map(Argument.from_string, list(filter(bool, section_args.split("\n")))))
+        args = list(map(Argument.from_string, filter(bool, section_args.split("\n"))))
 
         if section in cls.single_arg_section_names:
             return args

--- a/openapi/docstring_parser.py
+++ b/openapi/docstring_parser.py
@@ -56,7 +56,7 @@ class Docstring(object):
             and not lines[i].startswith(":")
         ):
             i += 1
-        description = " ".join([_f for _f in lines[:i] if _f])
+        description = " ".join(filter(None, lines[:i]))
         return description.strip()
 
     @classmethod

--- a/openapi/docstring_parser.py
+++ b/openapi/docstring_parser.py
@@ -56,7 +56,7 @@ class Docstring(object):
             and not lines[i].startswith(":")
         ):
             i += 1
-        description = " ".join(filter(None, lines[:i]))
+        description = " ".join([_f for _f in lines[:i] if _f])
         return description.strip()
 
     @classmethod
@@ -74,7 +74,7 @@ class Docstring(object):
         except ValueError:
             pass
 
-        args = map(Argument.from_string, filter(bool, section_args.split("\n")))
+        args = list(map(Argument.from_string, list(filter(bool, section_args.split("\n")))))
 
         if section in cls.single_arg_section_names:
             return args

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cb
 gen3dictionary==2.0.1
 gen3datamodel==3.0.1
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
-git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
+git+https://git@github.com/uc-cdis/storage-client.git@01.0.0#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 authutils==3.1.1
 boto==2.36.0
 cryptography==2.3
-git+https://git+github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
+git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
 envelopes==0.4
 Flask==1.1.1
 flask-cors==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 authutils==3.1.1
 boto==2.36.0
 cryptography==2.3
-dictionaryutils==2.0.7
+-e git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
 envelopes==0.4
 Flask==1.1.1
 flask-cors==3.0.3
@@ -22,15 +22,15 @@ sqlalchemy==1.3.5
 Werkzeug==0.16.0
 xmltodict==0.9.2
 more-itertools==5.0.0
--e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
+-e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oauth2client
 cdispyutils==0.2.13
-datamodelutils==0.4.7
+-e git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 -e git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
--e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
+-e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
-gen3dictionary==2.0.0
-gen3datamodel==2.0.2
+-e git+https://git@github.com/uc-cdis/datadictionary.git@chore/py3#egg=gen3dictionary
+-e git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
 -e git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
 -e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,14 +23,13 @@ sqlalchemy==1.3.5
 Werkzeug==0.16.0
 xmltodict==0.9.2
 more-itertools==5.0.0
-git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oauth2client
-cdispyutils==0.2.13
-git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
-# TODO:update to pypi version once released
+cdis_oauth2client==1.0.0
+cdispyutils==1.0.0
+datamodelutils==1.0.0
 # required for gen3datamodel, not required for sheepdog
 psqlgraph==3.0.0
-git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
-git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
+cdiserrors==0.1.2
+cdislogging==1.0.0
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
 gen3datamodel==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
-git+https://git@github.com/uc-cdis/datadictionary.git@chore/py3#egg=gen3dictionary
+gen3dictionary==2.0.1
 git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
 git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,12 +27,12 @@ git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oaut
 cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 # TODO:update to pypi version once released
-git+https://git@github.com/uc-cdis/psqlgraph.git@chore/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
+psqlgraph=3.0.0
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
+gen3datamodel==3.0.0
 git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ cdiserrors==0.1.2
 cdislogging==1.0.0
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-gen3datamodel==3.0.0
+gen3datamodel==3.0.1
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 # TODO:update to pypi version once released
 # required for gen3datamodel, not required for sheepdog
-psqlgraph=3.0.0
+psqlgraph==3.0.0
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ Flask-SQLAlchemy-Session==1.1
 fuzzywuzzy==0.6.1
 gen3authz==0.2.1
 graphene==2.0.1
-rx==1.6.1
 jsonschema==2.5.1
 lxml==3.8.0
 pbr==2.0.0
@@ -26,7 +25,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.7
-psqlgraph==2.0.2
+-e https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fuzzywuzzy==0.6.1
 gen3authz==0.2.1
 graphene==2.0.1
 jsonschema==2.5.1
-lxml==3.8.0
+lxml==4.4.2
 pbr==2.0.0
 psycopg2==2.7.3.2
 python-keystoneclient==1.8.1
@@ -34,5 +34,5 @@ git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
 gen3datamodel==3.0.0
-git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
+git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Werkzeug==0.16.0
 xmltodict==0.9.2
 more-itertools==5.0.0
 cdis_oauth2client==1.0.0
-cdispyutils==1.0.0
+cdispyutils==1.0.3
 datamodelutils==1.0.0
 # required for gen3datamodel, not required for sheepdog
 psqlgraph==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cb
 gen3dictionary==2.0.1
 gen3datamodel==3.0.1
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
-git+https://git@github.com/uc-cdis/storage-client.git@01.0.0#egg=storageclient
+git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-authutils==3.1.1
+authutils==4.0.0
 boto==2.36.0
 cryptography==2.3
 git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oaut
 cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 # TODO:update to pypi version once released
-git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
+git+https://git@github.com/uc-cdis/psqlgraph.git@chore/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ more-itertools==5.0.0
 -e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@0.1.3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 datamodelutils==0.4.7
--e https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
+-e git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.1#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 authutils==3.1.1
 boto==2.36.0
 cryptography==2.3
--e git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
+git+https://git+github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
 envelopes==0.4
 Flask==1.1.1
 flask-cors==3.0.3
@@ -23,15 +23,15 @@ sqlalchemy==1.3.5
 Werkzeug==0.16.0
 xmltodict==0.9.2
 more-itertools==5.0.0
--e git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oauth2client
+git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oauth2client
 cdispyutils==0.2.13
--e git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
--e git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
+git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
+git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
--e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
--e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
--e git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
--e git+https://git@github.com/uc-cdis/datadictionary.git@chore/py3#egg=gen3dictionary
--e git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
--e git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
--e git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient
+git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
+git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
+git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
+git+https://git@github.com/uc-cdis/datadictionary.git@chore/py3#egg=gen3dictionary
+git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
+git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
+git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 authutils==4.0.0
 boto==2.36.0
 cryptography==2.3
-git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
+dictionaryutils==3.0.0
 envelopes==0.4
 Flask==1.1.1
 flask-cors==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ more-itertools==5.0.0
 git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oauth2client
 cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
+# TODO:update to pypi version once released
 git+https://git@github.com/NCI-GDC/psqlgraph.git@release/py3#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ python-keystoneclient==1.8.1
 PyYAML==5.1
 requests==2.22.0
 setuptools==30.1.0
+six==1.12.0
 simplejson==3.8.1
 sqlalchemy==1.3.5
 Werkzeug==0.16.0

--- a/run.py
+++ b/run.py
@@ -123,10 +123,10 @@ def run_with_fake_authz():
     """
     authorized = True  # modify this to mock authorized/unauthorized
     with patch(
-        'gen3authz.client.arborist.client.ArboristClient.create_resource',
+        "gen3authz.client.arborist.client.ArboristClient.create_resource",
         new_callable=PropertyMock,
     ), patch(
-        'gen3authz.client.arborist.client.ArboristClient.auth_request',
+        "gen3authz.client.arborist.client.ArboristClient.auth_request",
         new_callable=PropertyMock,
         return_value=lambda jwt, service, methods, resources: authorized,
     ):

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ from sheepdog.api import run_for_development
 
 requests.packages.urllib3.disable_warnings()
 
-all_role_values = all_roles.values()
+all_role_values = list(all_roles.values())
 roles = defaultdict(lambda: all_role_values)
 
 

--- a/sheepdog/auth/__init__.py
+++ b/sheepdog/auth/__init__.py
@@ -22,7 +22,9 @@ logger = get_logger(__name__)
 try:
     from authutils.token.validate import validate_request
 except ImportError:
-    logger.warning("Unable to import authutils validate_request. Sheepdog will error if config AUTH_SUBMISSION_LIST is set to True (note that it is True by default)")
+    logger.warning(
+        "Unable to import authutils validate_request. Sheepdog will error if config AUTH_SUBMISSION_LIST is set to True (note that it is True by default)"
+    )
 
 
 def get_jwt_from_header():
@@ -52,7 +54,7 @@ def authorize_for_project(*required_roles):
                 jwt=jwt,
                 service="sheepdog",
                 methods=required_roles,
-                resources=[resource]
+                resources=[resource],
             )
             if not authz:
                 raise AuthZError("user is unauthorized")
@@ -67,10 +69,7 @@ def authorize(program, project, roles):
     resource = "/programs/{}/projects/{}".format(program, project)
     jwt = get_jwt_from_header()
     authz = flask.current_app.auth.auth_request(
-        jwt=jwt,
-        service="sheepdog",
-        methods=roles,
-        resources=[resource]
+        jwt=jwt, service="sheepdog", methods=roles, resources=[resource]
     )
     if not authz:
         raise AuthZError("user is unauthorized")
@@ -84,12 +83,14 @@ def create_resource(program, project=None):
 
     json_data = {
         "name": resource,
-        "description": "Created by sheepdog"  # TODO use authz provider field
+        "description": "Created by sheepdog",  # TODO use authz provider field
     }
     resp = flask.current_app.auth.create_resource(
-        parent_path="",
-        resource_json=json_data,
-        create_parents=True
+        parent_path="", resource_json=json_data, create_parents=True
     )
     if resp and resp.get("error"):
-        logger.error("Unable to create resource: code {} - {}".format(resp.error.code, resp.error.message))
+        logger.error(
+            "Unable to create resource: code {} - {}".format(
+                resp.error.code, resp.error.message
+            )
+        )

--- a/sheepdog/blueprint/routes/views/__init__.py
+++ b/sheepdog/blueprint/routes/views/__init__.py
@@ -182,7 +182,7 @@ def get_dictionary():
              ]
            }
     """
-    keys = dictionary.schema.keys() + ["_all"]
+    keys = list(dictionary.schema.keys()) + ["_all"]
     links = [flask.url_for(".get_dictionary_entry", entry=entry) for entry in keys]
     return flask.jsonify({"links": links})
 

--- a/sheepdog/blueprint/routes/views/__init__.py
+++ b/sheepdog/blueprint/routes/views/__init__.py
@@ -132,7 +132,7 @@ def root_create():
             node_id = node.node_id
             node.props["dbgap_accession_number"] = phsid
         else:
-            node_id = str(uuid.uuid5(PROGRAM_SEED, program.encode("utf-8")))
+            node_id = str(uuid.uuid5(PROGRAM_SEED, program))
             session.add(
                 models.Program(  # pylint: disable=not-callable
                     node_id, name=program, dbgap_accession_number=phsid

--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -148,7 +148,6 @@ def create_project(program):
     project = doc.get("code")
     if not project:
         raise UserError("No project specified in key 'code'")
-    project = project
     # Parse dbgap accession number.
     phsid = doc.get("dbgap_accession_number")
     if not phsid:

--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -102,7 +102,6 @@ def create_project(program):
     Args:
         program (str): |program_id|
         body (schema_project): input body
-    
     Responses:
         200: Registered successfully.
         400: User error.
@@ -149,7 +148,7 @@ def create_project(program):
     project = doc.get("code")
     if not project:
         raise UserError("No project specified in key 'code'")
-    project = project.encode("utf-8")
+    project = project
     # Parse dbgap accession number.
     phsid = doc.get("dbgap_accession_number")
     if not phsid:
@@ -165,7 +164,7 @@ def create_project(program):
         node = utils.lookup_project(flask.current_app.db, program, project)
         if not node:
             # Create a new project node
-            node_uuid = str(uuid.uuid5(PROJECT_SEED, project.encode("utf-8")))
+            node_uuid = str(uuid.uuid5(PROJECT_SEED, project))
             if flask.current_app.db.nodes(models.Project).ids(node_uuid).first():
                 raise UserError(
                     "ERROR: Project {} already exists in DB".format(project)

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -276,7 +276,7 @@ def get_entities_by_id(program, project, entity_id_string):
             raise UserError(
                 "Not found: {}".format(", ".join(missing_entities), code=404)
             )
-        return flask.jsonify({"entities": utils.create_entity_list(list(entities.values()))})
+        return flask.jsonify({"entities": utils.create_entity_list(entities.values())})
 
 
 def create_delete_entities_viewer(dry_run=False):

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -410,7 +410,11 @@ def export_entities(program, project):
     project_id = "{}-{}".format(program, project)
     file_format = kwargs.get("file_format") or "tsv"
 
-    mimetype = "application/json" if file_format.lower() == "json" else "application/octet-stream"
+    mimetype = (
+        "application/json"
+        if file_format.lower() == "json"
+        else "application/octet-stream"
+    )
     if not kwargs.get("ids"):
         if not node_label:
             raise UserError("expected either `ids` or `node_label` parameter")
@@ -516,9 +520,7 @@ def create_files_viewer(dry_run=False, reassign=False):
         auth.current_user.require_admin()
 
         headers = {
-            k: v
-            for k, v in flask.request.headers.items()
-            if v and k != "X-Auth-Token"
+            k: v for k, v in flask.request.headers.items() if v and k != "X-Auth-Token"
         }
         url = flask.request.url.split("?")
         args = url[-1] if len(url) > 1 else ""

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -133,7 +133,7 @@ def get_project_dictionary(program=None, project=None):
     """
     if flask.current_app.config.get("AUTH_SUBMISSION_LIST", True) is True:
         auth.validate_request(aud={"openid"}, purpose=None)
-    keys = dictionary.schema.keys() + ["_all"]
+    keys = list(dictionary.schema.keys()) + ["_all"]
     links = [
         flask.url_for(
             ".get_project_dictionary_entry",
@@ -194,7 +194,7 @@ def get_dictionary_entry(entry):
     """
     resolvers = {
         key.replace(".yaml", ""): resolver.source
-        for key, resolver in dictionary.resolvers.iteritems()
+        for key, resolver in dictionary.resolvers.items()
     }
     if entry in resolvers:
         return flask.jsonify(resolvers[entry])
@@ -276,7 +276,7 @@ def get_entities_by_id(program, project, entity_id_string):
             raise UserError(
                 "Not found: {}".format(", ".join(missing_entities), code=404)
             )
-        return flask.jsonify({"entities": utils.create_entity_list(entities.values())})
+        return flask.jsonify({"entities": utils.create_entity_list(list(entities.values()))})
 
 
 def create_delete_entities_viewer(dry_run=False):
@@ -397,7 +397,7 @@ def export_entities(program, project):
 
     if flask.request.method == "GET":
         # Unpack multidict, or values will unnecessarily be lists.
-        kwargs = {k: v for k, v in flask.request.args.iteritems()}
+        kwargs = {k: v for k, v in flask.request.args.items()}
     else:
         kwargs = utils.parse.parse_request_json()
 
@@ -517,7 +517,7 @@ def create_files_viewer(dry_run=False, reassign=False):
 
         headers = {
             k: v
-            for k, v in flask.request.headers.iteritems()
+            for k, v in flask.request.headers.items()
             if v and k != "X-Auth-Token"
         }
         url = flask.request.url.split("?")

--- a/sheepdog/transactions/deletion/entity.py
+++ b/sheepdog/transactions/deletion/entity.py
@@ -33,7 +33,6 @@ class DeletionEntity(EntityBase):
                 )
             )
 
-
     @property
     def secondary_keys(self):
         """Return the list of unique dicts for the node"""

--- a/sheepdog/transactions/deletion/entity.py
+++ b/sheepdog/transactions/deletion/entity.py
@@ -116,7 +116,7 @@ class DeletionEntity(EntityBase):
                 type=EntityErrors.INVALID_LINK,
                 dependents=[
                     {"id": node_id, "type": entity.node.label}
-                    for node_id, entity in self.dependents.iteritems()
+                    for node_id, entity in self.dependents.items()
                 ],
             )
 

--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -70,7 +70,7 @@ class DeletionTransaction(TransactionBase):
                 for e in self.valid_entities:
                     e.node.sysan["to_delete"] = self.to_delete
             else:
-                map(self.session.delete, [e.node for e in self.valid_entities])
+                list(map(self.session.delete, [e.node for e in self.valid_entities]))
 
     def _delete_fields(self):
         """

--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -71,7 +71,7 @@ class DeletionTransaction(TransactionBase):
                 for e in self.valid_entities:
                     e.node.sysan["to_delete"] = self.to_delete
             else:
-                map(self.session.delete, [e.node for e in self.valid_entities])
+                list(map(self.session.delete, [e.node for e in self.valid_entities]))
 
     def _delete_fields(self):
         """

--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -14,7 +14,6 @@ class DeletionTransaction(TransactionBase):
         self.fields_to_delete = kwargs.get("fields", None)
         self.to_delete = kwargs.get("to_delete", None)
 
-
     def write_transaction_log(self):
         """Save a log noting this project was opened"""
 

--- a/sheepdog/transactions/deletion/transaction.py
+++ b/sheepdog/transactions/deletion/transaction.py
@@ -71,7 +71,7 @@ class DeletionTransaction(TransactionBase):
                 for e in self.valid_entities:
                     e.node.sysan["to_delete"] = self.to_delete
             else:
-                list(map(self.session.delete, [e.node for e in self.valid_entities]))
+                map(self.session.delete, [e.node for e in self.valid_entities])
 
     def _delete_fields(self):
         """

--- a/sheepdog/transactions/entity_base.py
+++ b/sheepdog/transactions/entity_base.py
@@ -22,9 +22,7 @@ class EntityErrors(object):
     UNCATEGORIZED = "ERROR"
 
 
-class EntityBase(object):
-
-    __metaclass__ = abc.ABCMeta
+class EntityBase(object, metaclass=abc.ABCMeta):
 
     def __init__(self, transaction, node=None):
         self.transaction = transaction
@@ -129,7 +127,7 @@ class EntityBase(object):
         """
         Snapshot the properties as they are now to put in transaction log.
         """
-        self.old_props = {k: v for k, v in self.node.props.iteritems()}
+        self.old_props = {k: v for k, v in self.node.props.items()}
 
     def record_error(self, message, keys=None, type=None, **kwargs):
         """

--- a/sheepdog/transactions/entity_base.py
+++ b/sheepdog/transactions/entity_base.py
@@ -23,7 +23,6 @@ class EntityErrors(object):
 
 
 class EntityBase(object, metaclass=abc.ABCMeta):
-
     def __init__(self, transaction, node=None):
         self.transaction = transaction
         self.logger = self.transaction.logger
@@ -96,7 +95,6 @@ class EntityBase(object, metaclass=abc.ABCMeta):
             .count()
         )
         return count > 0
-
 
     def get_links(self, node):
         """Return the possible links to submittable entities given a node."""

--- a/sheepdog/transactions/release/transaction.py
+++ b/sheepdog/transactions/release/transaction.py
@@ -32,7 +32,10 @@ class ReleaseTransaction(TransactionBase):
             return self.record_error("Project is already released.")
 
         if project.releasable is not True:
-            message = "Project is not releasable. " "Project must be submitted at least once first."
+            message = (
+                "Project is not releasable. "
+                "Project must be submitted at least once first."
+            )
             return self.record_error(message)
 
         project.released = True

--- a/sheepdog/transactions/transaction_base.py
+++ b/sheepdog/transactions/transaction_base.py
@@ -77,7 +77,7 @@ class TransactionBase(object):
         #: database during claim_transaction_log()
         self.transaction_id = kwargs.pop("transaction_id", None)
         if kwargs:
-            self.logger.warn("Unused arguments: %s", kwargs.keys())
+            self.logger.warn("Unused arguments: %s", list(kwargs.keys()))
 
         self.graph_validator = validators.GDCGraphValidator()
         self.transactional_errors = []

--- a/sheepdog/transactions/upload/__init__.py
+++ b/sheepdog/transactions/upload/__init__.py
@@ -100,7 +100,7 @@ def handle_single_transaction(role, program, project, **tx_kwargs):
     This function multiplexes on the content-type to call the appropriate
     transaction handler.
     """
-    doc = flask.request.get_data().decode('utf-8')
+    doc = flask.request.get_data().decode("utf-8")
     content_type = flask.request.headers.get("Content-Type", "").lower()
     if content_type == "text/csv":
         doc_format = "csv"

--- a/sheepdog/transactions/upload/__init__.py
+++ b/sheepdog/transactions/upload/__init__.py
@@ -100,7 +100,7 @@ def handle_single_transaction(role, program, project, **tx_kwargs):
     This function multiplexes on the content-type to call the appropriate
     transaction handler.
     """
-    doc = flask.request.get_data()
+    doc = flask.request.get_data().decode('utf-8')
     content_type = flask.request.headers.get("Content-Type", "").lower()
     if content_type == "text/csv":
         doc_format = "csv"
@@ -273,7 +273,7 @@ def handle_biospecimen_bcr_xml_transaction(role, program, project, **tx_kwargs):
     """
     Entrypoint from the flask blueprint for BCR Biospecimen XML XSD 2.6
     """
-    project_node_id = str(uuid.uuid5(PROJECT_SEED, project.encode("utf-8")))
+    project_node_id = str(uuid.uuid5(PROJECT_SEED, project))
     parser = utils.transforms.BcrXmlToJsonParser(project_node_id)
     return handle_xml_transaction(role, program, project, parser, **tx_kwargs)
 

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -289,7 +289,7 @@ class UploadEntity(EntityBase):
                 )
 
         # Fill in default system property values
-        for key, val in self.get_system_property_defaults().iteritems():
+        for key, val in self.get_system_property_defaults().items():
             if self.doc.get(key, None) is None:
                 self.doc[key] = val
 
@@ -341,7 +341,7 @@ class UploadEntity(EntityBase):
                 type=EntityErrors.INVALID_PERMISSIONS,
             )
 
-        self.old_props = {k: v for k, v in node.props.iteritems()}
+        self.old_props = {k: v for k, v in node.props.items()}
 
         if node.label != self.entity_type:
             self.record_error(
@@ -413,7 +413,7 @@ class UploadEntity(EntityBase):
             self.doc[name] = doc_links
 
             # Get set of node ids in the link document
-            map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")])
+            list(map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")]))
 
             # Get set of secondary_keys in the link document
             for link in doc_links:
@@ -433,7 +433,7 @@ class UploadEntity(EntityBase):
                 self.doc.pop(name)
 
     def _remove_empty_values(self, doc):
-        for key in doc.keys():
+        for key in list(doc.keys()):
             value = doc[key]
 
             if isinstance(value, dict):
@@ -462,12 +462,12 @@ class UploadEntity(EntityBase):
 
         special_keys = ["type", "id", "created_datetime", "updated_datetime"]
         pg_props = self.node.get_pg_properties()
-        prop_keys = pg_props.keys() + self.node._pg_links.keys() + special_keys
+        prop_keys = list(pg_props.keys()) + list(self.node._pg_links.keys()) + special_keys
         self.node.project_id = self.transaction.project_id
         default_props = self.get_system_property_defaults()
 
         # Set properties
-        for key, val in self.doc.iteritems():
+        for key, val in self.doc.items():
 
             # Does this key exist?
             if key not in prop_keys:
@@ -483,7 +483,7 @@ class UploadEntity(EntityBase):
                 pass
 
             # If key is a link, skip for now
-            elif key in self.node._pg_links.keys():
+            elif key in list(self.node._pg_links.keys()):
                 pass
 
             # Is it a system property?
@@ -577,7 +577,7 @@ class UploadEntity(EntityBase):
             node["project_id"] = project_id
 
         # Set given properties.
-        for key, val in properties.iteritems():
+        for key, val in properties.items():
             if key in node.__pg_properties__:
                 try:
                     node[key] = val

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -413,7 +413,7 @@ class UploadEntity(EntityBase):
             self.doc[name] = doc_links
 
             # Get set of node ids in the link document
-            map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")])
+            list(map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")]))
 
             # Get set of secondary_keys in the link document
             for link in doc_links:

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -413,7 +413,7 @@ class UploadEntity(EntityBase):
             self.doc[name] = doc_links
 
             # Get set of node ids in the link document
-            list(map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")]))
+            map(doc_ids.add, [l.get("id") for l in doc_links if l.get("id")])
 
             # Get set of secondary_keys in the link document
             for link in doc_links:

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -462,7 +462,9 @@ class UploadEntity(EntityBase):
 
         special_keys = ["type", "id", "created_datetime", "updated_datetime"]
         pg_props = self.node.get_pg_properties()
-        prop_keys = list(pg_props.keys()) + list(self.node._pg_links.keys()) + special_keys
+        prop_keys = (
+            list(pg_props.keys()) + list(self.node._pg_links.keys()) + special_keys
+        )
         self.node.project_id = self.transaction.project_id
         default_props = self.get_system_property_defaults()
 

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -433,7 +433,7 @@ class UploadEntity(EntityBase):
                 self.doc.pop(name)
 
     def _remove_empty_values(self, doc):
-        for key in list(doc.keys()):
+        for key in doc.keys():
             value = doc[key]
 
             if isinstance(value, dict):
@@ -483,7 +483,7 @@ class UploadEntity(EntityBase):
                 pass
 
             # If key is a link, skip for now
-            elif key in list(self.node._pg_links.keys()):
+            elif key in self.node._pg_links.keys():
                 pass
 
             # Is it a system property?

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -575,7 +575,7 @@ class FileUploadEntity(UploadEntity):
         # check that the provided hash/size match those of the file in indexd
         # submitted hashes have to be a subset of the indexd ones
         hashes_match = all(
-            item in list(file_hashes.items()) for item in list(self._get_file_hashes().items())
+            item in file_hashes.items() for item in self._get_file_hashes().items()
         )
         sizes_match = self._get_file_size() == file_size
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -345,7 +345,7 @@ class FileUploadEntity(UploadEntity):
             # remove url metadata for deleted urls if that happens
             document.urls_metadata = {
                 k: v
-                for (k, v) in document.urls_metadata.iteritems()
+                for (k, v) in document.urls_metadata.items()
                 if k in document.urls
             }
             document.patch()
@@ -575,7 +575,7 @@ class FileUploadEntity(UploadEntity):
         # check that the provided hash/size match those of the file in indexd
         # submitted hashes have to be a subset of the indexd ones
         hashes_match = all(
-            item in file_hashes.items() for item in self._get_file_hashes().items()
+            item in list(file_hashes.items()) for item in list(self._get_file_hashes().items())
         )
         sizes_match = self._get_file_size() == file_size
 

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -337,7 +337,7 @@ class FileUploadEntity(UploadEntity):
             self.object_id = str(doc.did)
             self.node._props["object_id"] = self.object_id
 
-        self._create_alias(record=alias, hashes=hashes, size=size, release="private")
+        self._create_alias(alias, doc.did)
 
     def _update_index(self):
         """
@@ -709,8 +709,8 @@ class FileUploadEntity(UploadEntity):
             return self.doc.get("file_size")
         return None
 
-    def _create_alias(self, **kwargs):
-        return self.transaction.index_client.create_alias(**kwargs)
+    def _create_alias(self, alias, did):
+        return self.transaction.index_client.add_alias_for_did(alias, did)
 
     def _create_index(self, **kwargs):
         return self.transaction.index_client.create(**kwargs)

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -146,11 +146,7 @@ class FileUploadEntity(UploadEntity):
         self._populate_files_from_index()
 
         # file already indexed and object_id provided: data upload flow
-        if (
-            self.use_object_id(self.entity_type)
-            and self.object_id
-            and self.file_exists
-        ):
+        if self.use_object_id(self.entity_type) and self.object_id and self.file_exists:
             if self._is_valid_hash_size_for_file():
                 self.should_update_acl_uploader = True
         else:
@@ -237,10 +233,15 @@ class FileUploadEntity(UploadEntity):
                     # in the data upload flow case,
                     # while we don't have a way to do it properly (i.e. with permissions checks)
                     document = self.file_by_uuid or self.file_by_hash
-                    namespace = flask.current_app.config.get("AUTH_NAMESPACE", "").rstrip("/")
+                    namespace = flask.current_app.config.get(
+                        "AUTH_NAMESPACE", ""
+                    ).rstrip("/")
                     authz = [
-                        "{}/programs/{}/projects/{}"
-                        .format(namespace, self.transaction.program, self.transaction.project)
+                        "{}/programs/{}/projects/{}".format(
+                            namespace,
+                            self.transaction.program,
+                            self.transaction.project,
+                        )
                     ]
                     use_consent_codes = (
                         dictionary.schema.get(self.entity_type, {})
@@ -308,8 +309,9 @@ class FileUploadEntity(UploadEntity):
 
         namespace = flask.current_app.config.get("AUTH_NAMESPACE", "").rstrip("/")
         authz = [
-            "{}/programs/{}/projects/{}"
-            .format(namespace, self.transaction.program, self.transaction.project)
+            "{}/programs/{}/projects/{}".format(
+                namespace, self.transaction.program, self.transaction.project
+            )
         ]
         use_consent_codes = (
             dictionary.schema.get(self.entity_type, {})
@@ -323,7 +325,11 @@ class FileUploadEntity(UploadEntity):
 
         # IndexClient
         doc = self._create_index(
-            did=self.file_index, hashes=hashes, size=size, urls=urls, acl=acl,
+            did=self.file_index,
+            hashes=hashes,
+            size=size,
+            urls=urls,
+            acl=acl,
             authz=authz,
         )
 
@@ -344,9 +350,7 @@ class FileUploadEntity(UploadEntity):
             document.urls = self.urls
             # remove url metadata for deleted urls if that happens
             document.urls_metadata = {
-                k: v
-                for (k, v) in document.urls_metadata.items()
-                if k in document.urls
+                k: v for (k, v) in document.urls_metadata.items() if k in document.urls
             }
             document.patch()
 
@@ -629,13 +633,14 @@ class FileUploadEntity(UploadEntity):
             # This must be done via _put and _load as opposed to using document.patch()
             # because the uploader field is (correctly) not in indexclient's UPDATABLE_ATTRS
             self.transaction.index_client._put(
-                "index", self.object_id,
+                "index",
+                self.object_id,
                 headers={"content-type": "application/json"},
                 data=data,
                 params={"rev": self.file_by_uuid.rev},
                 auth=self.transaction.index_client.auth,
             )
-            self.file_by_uuid._load() # to sync new rev from server
+            self.file_by_uuid._load()  # to sync new rev from server
         except requests.HTTPError as e:
             self.record_error(
                 "Failed to update acl and uploader fields in indexd: {}".format(

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -422,9 +422,9 @@ class BulkUploadTransaction(TransactionBase):
             return {item: count for item, count in counter if count > 1}
 
         ids = [entity.entity_id for entity in self.entities]
-        dup_ids = duplicates(list(Counter(ids).items()))
+        dup_ids = duplicates(Counter(ids).items())
         secondary_keys = [e.secondary_keys for e in self.entities]
-        dup_secondary_keys = duplicates(iter(Counter(secondary_keys).items()))
+        dup_secondary_keys = duplicates(Counter(secondary_keys).items())
         # Check secondary_keys
         for sk in dup_secondary_keys.keys():
             for entity in self.entities:

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -162,22 +162,21 @@ class UploadTransaction(TransactionBase):
         for entity in self.valid_entities:
             schema = gdcdictionary.schema[entity.node.label]
             node = entity.node
-            for keys in schema['uniqueKeys']:
+            for keys in schema["uniqueKeys"]:
                 props = {}
-                if keys == ['id']:
+                if keys == ["id"]:
                     continue
                 for key in keys:
-                    prop = schema['properties'][key].get('systemAlias')
+                    prop = schema["properties"][key].get("systemAlias")
                     if prop:
                         props[prop] = node[prop]
                     else:
                         props[key] = node[key]
                 if self.db_driver.nodes(type(node)).props(props).count() > 0:
-                        entity.record_error(
-                            '{} with {} already exists in the DB'
-                            .format(node.label, props), keys=list(props.keys())
-                        )
-
+                    entity.record_error(
+                        "{} with {} already exists in the DB".format(node.label, props),
+                        keys=list(props.keys()),
+                    )
 
     def instantiate(self):
         """Create a SQLAlchemy model for all transaction entities."""

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -175,7 +175,7 @@ class UploadTransaction(TransactionBase):
                 if self.db_driver.nodes(type(node)).props(props).count() > 0:
                         entity.record_error(
                             '{} with {} already exists in the DB'
-                            .format(node.label, props), keys=props.keys()
+                            .format(node.label, props), keys=list(props.keys())
                         )
 
 
@@ -422,11 +422,11 @@ class BulkUploadTransaction(TransactionBase):
             return {item: count for item, count in counter if count > 1}
 
         ids = [entity.entity_id for entity in self.entities]
-        dup_ids = duplicates(Counter(ids).items())
+        dup_ids = duplicates(list(Counter(ids).items()))
         secondary_keys = [e.secondary_keys for e in self.entities]
-        dup_secondary_keys = duplicates(Counter(secondary_keys).iteritems())
+        dup_secondary_keys = duplicates(iter(Counter(secondary_keys).items()))
         # Check secondary_keys
-        for sk in dup_secondary_keys.keys():
+        for sk in list(dup_secondary_keys.keys()):
             for entity in self.entities:
                 if entity.secondary_keys == sk:
                     entity.record_error(
@@ -435,7 +435,7 @@ class BulkUploadTransaction(TransactionBase):
                     )
 
         # Check GDC ids
-        for ID in dup_ids.keys():
+        for ID in list(dup_ids.keys()):
             for entity in self.entities:
                 if entity.entity_id == ID:
                     entity.record_error(

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -426,7 +426,7 @@ class BulkUploadTransaction(TransactionBase):
         secondary_keys = [e.secondary_keys for e in self.entities]
         dup_secondary_keys = duplicates(iter(Counter(secondary_keys).items()))
         # Check secondary_keys
-        for sk in list(dup_secondary_keys.keys()):
+        for sk in dup_secondary_keys.keys():
             for entity in self.entities:
                 if entity.secondary_keys == sk:
                     entity.record_error(
@@ -435,7 +435,7 @@ class BulkUploadTransaction(TransactionBase):
                     )
 
         # Check GDC ids
-        for ID in list(dup_ids.keys()):
+        for ID in dup_ids.keys():
             for entity in self.entities:
                 if entity.entity_id == ID:
                     entity.record_error(

--- a/sheepdog/utils/__init__.py
+++ b/sheepdog/utils/__init__.py
@@ -13,7 +13,6 @@ import os
 import io
 import tarfile
 import time
-import urllib.parse
 
 import boto
 import flask

--- a/sheepdog/utils/__init__.py
+++ b/sheepdog/utils/__init__.py
@@ -10,10 +10,10 @@ import csv
 import functools
 import json
 import os
-import StringIO
+import io
 import tarfile
 import time
-import urlparse
+import urllib.parse
 
 import boto
 import flask
@@ -173,7 +173,7 @@ def check_action_allowed_in_state(action, file_state):
 def create_entity_list(nodes):
     docs = []
     for node in nodes:
-        props = {k: v for k, v in node.props.iteritems()}
+        props = {k: v for k, v in node.props.items()}
         props["id"] = node.node_id
         props["type"] = node.label
         if hasattr(node, "project_id"):
@@ -204,7 +204,7 @@ def get_all_template(file_format, categories=None, exclude=None, **kwargs):
     exclude = exclude.split(",") if exclude else []
     entity_types = [
         entity_type
-        for entity_type, schema in dictionary.schema.iteritems()
+        for entity_type, schema in dictionary.schema.items()
         if "project_id" in schema.get("properties", {})
         and (not categories or schema["category"] in categories)
         and (not exclude or entity_type not in exclude)
@@ -227,7 +227,7 @@ def get_delimited_template(entity_types, file_format, filename=TEMPLATE_NAME):
     Return:
         ``file_format`` (TSV or CSV) template for entity types.
     """
-    tar_obj = StringIO.StringIO()
+    tar_obj = io.StringIO()
     tar = tarfile.open(filename, mode="w|gz", fileobj=tar_obj)
 
     for entity_type in entity_types:
@@ -235,7 +235,7 @@ def get_delimited_template(entity_types, file_format, filename=TEMPLATE_NAME):
         partname = "{}.{}".format(entity_type, file_format)
         tarinfo = tarfile.TarInfo(name=partname)
         tarinfo.size = len(content)
-        tar.addfile(tarinfo, StringIO.StringIO(content))
+        tar.addfile(tarinfo, io.StringIO(content))
 
     tar.close()
     return tar_obj.getvalue()

--- a/sheepdog/utils/manifest.py
+++ b/sheepdog/utils/manifest.py
@@ -58,7 +58,7 @@ def get_manifest(program, project, ids):
     # it here and add the local_file_path
     files = [
         dict(local_file_path=doc.get("file_name"), **doc)
-        for file_type in exporter.result.values()
+        for file_type in list(exporter.result.values())
         for doc in file_type
     ]
 

--- a/sheepdog/utils/manifest.py
+++ b/sheepdog/utils/manifest.py
@@ -58,7 +58,7 @@ def get_manifest(program, project, ids):
     # it here and add the local_file_path
     files = [
         dict(local_file_path=doc.get("file_name"), **doc)
-        for file_type in list(exporter.result.values())
+        for file_type in exporter.result.values()
         for doc in file_type
     ]
 

--- a/sheepdog/utils/parse.py
+++ b/sheepdog/utils/parse.py
@@ -18,7 +18,7 @@ def oph_raise_for_duplicates(object_pairs):
     with a message describing all violations.
     """
     counter = Counter(p[0] for p in object_pairs)
-    duplicates = [p for p in counter.iteritems() if p[1] > 1]
+    duplicates = [p for p in counter.items() if p[1] > 1]
     if duplicates:
         raise ValueError(
             "The document contains duplicate keys: {}".format(

--- a/sheepdog/utils/s3.py
+++ b/sheepdog/utils/s3.py
@@ -3,7 +3,7 @@ TODO
 """
 
 import socket
-import urlparse
+import urllib.parse
 
 import boto
 import flask
@@ -42,7 +42,7 @@ def make_s3_request(project_id, uuid, data, args, headers, method, action):
     key_name = project_id + "/" + uuid
     bucket = None
     if action in UPLOADING_PARTS:
-        upload_id = urlparse.parse_qs(args)["uploadId"][0]
+        upload_id = urllib.parse.parse_qs(args)["uploadId"][0]
         for ip in get_s3_hosts():
             bucket = get_submission_bucket()
             res = bucket.connection.make_request(

--- a/sheepdog/utils/scheduling.py
+++ b/sheepdog/utils/scheduling.py
@@ -1,4 +1,4 @@
-from Queue import Queue, Full
+from queue import Queue, Full
 from threading import Thread
 
 from cdislogging import get_logger

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -103,7 +103,7 @@ class DelimitedConverter(object):
         """
         try:
             self.set_reader(doc)
-            map(self.add_row, self.reader)
+            list(map(self.add_row, self.reader))
         except Exception as e:
             current_app.logger.exception(e)
             raise UserError("Unable to parse document")

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -50,7 +50,7 @@ def set_row_type(row):
 
 def strip(text):
     """
-    Strip if the text is a basestring
+    Strip if the text is a string
     """
 
     if not isinstance(text, str):
@@ -103,7 +103,7 @@ class DelimitedConverter(object):
         """
         try:
             self.set_reader(doc)
-            list(map(self.add_row, self.reader))
+            map(self.add_row, self.reader)
         except Exception as e:
             current_app.logger.exception(e)
             raise UserError("Unable to parse document")

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -3,7 +3,7 @@ TODO
 """
 
 import csv
-import StringIO
+import io
 
 from flask import current_app
 from psqlgraph import Node
@@ -53,7 +53,7 @@ def strip(text):
     Strip if the text is a basestring
     """
 
-    if not isinstance(text, basestring):
+    if not isinstance(text, str):
         return text
 
     else:
@@ -65,17 +65,17 @@ def strip_whitespace_from_str_dict(dictionary):
     Return new dict with leading/trailing whitespace removed from keys and
     values.
     """
-    return {strip(key): strip(value) for key, value in dictionary.iteritems()}
+    return {strip(key): strip(value) for key, value in dictionary.items()}
 
 
 def get_links_from_row(row):
     """Return a dict of key/value pairs that are links."""
-    return {k: v for k, v in row.iteritems() if "." in k}
+    return {k: v for k, v in row.items() if "." in k}
 
 
 def get_props_from_row(row):
     """Return a dict of key/value pairs that are props, not links."""
-    return {k: v for k, v in row.iteritems() if "." not in k and v != ""}
+    return {k: v for k, v in row.items() if "." not in k and v != ""}
 
 
 class DelimitedConverter(object):
@@ -84,7 +84,7 @@ class DelimitedConverter(object):
     """
 
     def __init__(self):
-        self.reader = csv.reader(StringIO.StringIO(""))
+        self.reader = csv.reader(io.StringIO(""))
         self.errors = []
         self.docs = []
 
@@ -103,7 +103,7 @@ class DelimitedConverter(object):
         """
         try:
             self.set_reader(doc)
-            map(self.add_row, self.reader)
+            list(map(self.add_row, self.reader))
         except Exception as e:
             current_app.logger.exception(e)
             raise UserError("Unable to parse document")
@@ -145,7 +145,7 @@ class DelimitedConverter(object):
 
         # Add properties
         props_dict = get_props_from_row(row)
-        for key, value in props_dict.iteritems():
+        for key, value in props_dict.items():
             if value == "null":
                 doc[key] = None
             else:
@@ -155,10 +155,10 @@ class DelimitedConverter(object):
 
         # Add links
         links_dict = get_links_from_row(row)
-        for key, value in links_dict.iteritems():
+        for key, value in links_dict.items():
             self.add_link_value(links, cls, key, value)
 
-        doc.update({k: v.values() for k, v in links.iteritems()})
+        doc.update({k: list(v.values()) for k, v in links.items()})
         self.docs.append(doc)
 
     def add_link_value(self, links, cls, key, value):
@@ -259,7 +259,7 @@ class TSVToJSONConverter(DelimitedConverter):
     def set_reader(self, doc):
         # Standardize the new line format
         doc = "\n".join(strip(doc).splitlines())
-        f = StringIO.StringIO(doc)
+        f = io.StringIO(doc)
         self.reader = csv.DictReader(f, delimiter="\t")
 
 
@@ -267,5 +267,5 @@ class CSVToJSONConverter(DelimitedConverter):
     def set_reader(self, doc):
         # Standardize the new line format
         doc = "\n".join(strip(doc).splitlines())
-        f = StringIO.StringIO(doc)
+        f = io.StringIO(doc)
         self.reader = csv.DictReader(f, delimiter=",")

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -82,7 +82,7 @@ def validated_parse(xml):
     except etree.XMLSyntaxError as msg:
         log.error("User submitted invalid xml: {}".format(msg))
         raise
-    schemas = list(map(_fetch_schema, _parse_schema_location(root)))
+    schemas = map(_fetch_schema, _parse_schema_location(root))
     try:
         for schema in schemas:
             schema.assertValid(root)
@@ -475,7 +475,7 @@ class BcrXmlToJsonParser(object):
         edges = {}
         if "edges" not in params or not params.edges:
             return edges
-        for edge_type, path in list(params.edges.items()):
+        for edge_type, path in params.edges.items():
             results = self.xpath(
                 path,
                 root,
@@ -518,7 +518,7 @@ class BcrXmlToJsonParser(object):
                         single=True,
                         label="{}: {}".format(entity_type, entity_id),
                     )
-                    for key, val in list(dst_kv.items())
+                    for key, val in dst_kv.items()
                 }
                 # TODO: fix
                 dsts = []
@@ -696,8 +696,8 @@ class BcrClinicalXmlToJsonParser(object):
                 doc[edge_cls.__src_dst_assoc__] = {"id": xpath}
 
     def insert_edges_by_property(self, doc, root, edges, namespaces):
-        for edge_label, edge in list(edges.items()):
-            for dst_label, dst_property in list(edge.items()):
+        for edge_label, edge in edges.items():
+            for dst_label, dst_property in edge.items():
                 edge_cls = flask.current_app.db.get_edge_by_labels(
                     doc["type"], edge_label, dst_label
                 )

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -217,7 +217,7 @@ class BcrXmlToJsonParser(object):
 
         self.xml_root = validated_parse(str(xml)).getroottree()
         self.namespaces = self.xml_root.getroot().nsmap
-        for entity_type, param_list in list(self.xml_mapping.items()):
+        for entity_type, param_list in self.xml_mapping.items():
             for params in param_list:
                 self.parse_entity(entity_type, params)
 
@@ -342,7 +342,7 @@ class BcrXmlToJsonParser(object):
 
         props = {}
         schema = dictionary.schema[entity_type]
-        for prop, args in list(params.properties.items()):
+        for prop, args in params.properties.items():
             if args is None:
                 if "null" in schema["properties"][prop].get("type", []):
                     props[prop] = None
@@ -388,7 +388,7 @@ class BcrXmlToJsonParser(object):
         if "const_properties" not in params or not params.const_properties:
             return {}
         props = {}
-        for prop, args in list(params.const_properties.items()):
+        for prop, args in params.const_properties.items():
             props[prop] = munge_property(args["value"], args["type"])
         return props
 
@@ -413,7 +413,7 @@ class BcrXmlToJsonParser(object):
 
         props = {}
         # Loop over all given datetime properties
-        for name, timespans in list(params.datetime_properties.items()):
+        for name, timespans in params.datetime_properties.items():
             times = {"year": 0, "month": 0, "day": 0}
             # Parse the year, month, day
             for span in times:
@@ -507,8 +507,8 @@ class BcrXmlToJsonParser(object):
             return edges
         return edges
 
-        for edge_type, dst_params in list(params.edges_by_property.items()):
-            for dst_label, dst_kv in list(dst_params.items()):
+        for edge_type, dst_params in params.edges_by_property.items():
+            for dst_label, dst_kv in dst_params.items():
                 dst_matches = {
                     key: self.xpath(
                         val,
@@ -535,7 +535,7 @@ class BcrXmlToJsonParser(object):
             return {}
 
         props = {}
-        for prop, args in list(params.edge_properties[edge_type].items()):
+        for prop, args in params.edge_properties[edge_type].items():
             path, _type = args["path"], args["type"]
             if not path:
                 continue
@@ -563,7 +563,7 @@ class BcrXmlToJsonParser(object):
 
         props = {}
         # Loop over all given datetime properties
-        for name, timespans in list(params.edge_datetime_properties[edge_type].items()):
+        for name, timespans in params.edge_datetime_properties[edge_type].items():
             times = {"year": 0, "month": 0, "day": 0}
 
             # Parse the year, month, day
@@ -638,7 +638,7 @@ class BcrClinicalXmlToJsonParser(object):
         if "clin_shared" not in namespaces:
             namespaces["clin_shared"] = "NA"
 
-        for data_type, params in list(self.xpath_ref.items()):
+        for data_type, params in self.xpath_ref.items():
             # Base properties
             schema = dictionary.schema[data_type]
             clinical = {"type": data_type}
@@ -681,8 +681,8 @@ class BcrClinicalXmlToJsonParser(object):
         return self
 
     def insert_edges(self, doc, root, edges, namespaces):
-        for edge_label, edge in list(edges.items()):
-            for dst_label, props in list(edge.items()):
+        for edge_label, edge in edges.items():
+            for dst_label, props in edge.items():
                 edge_cls = flask.current_app.db.get_edge_by_labels(
                     doc["type"], edge_label, dst_label
                 )
@@ -705,12 +705,12 @@ class BcrClinicalXmlToJsonParser(object):
                     root=root, namespaces=namespaces, nullable=False, **props
                 )
                 doc[edge_cls.__src_dst_assoc__] = {
-                    key: xpath(props) for key, props in list(dst_property.items())
+                    key: xpath(props) for key, props in dst_property.items()
                 }
 
     def insert_properties(self, doc, roots, properties, namespaces, schema):
         for root in roots:
-            for key, props in list(properties.items()):
+            for key, props in properties.items():
                 value = self.xpath(
                     root=root,
                     path=props["path"],

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -638,7 +638,7 @@ class BcrClinicalXmlToJsonParser(object):
         if "clin_shared" not in namespaces:
             namespaces["clin_shared"] = "NA"
 
-        for data_type, params in self.xpath_ref.items():
+        for data_type, params in list(self.xpath_ref.items()):
             # Base properties
             schema = dictionary.schema[data_type]
             clinical = {"type": data_type}
@@ -681,8 +681,8 @@ class BcrClinicalXmlToJsonParser(object):
         return self
 
     def insert_edges(self, doc, root, edges, namespaces):
-        for edge_label, edge in edges.items():
-            for dst_label, props in edge.items():
+        for edge_label, edge in list(edges.items()):
+            for dst_label, props in list(edge.items()):
                 edge_cls = flask.current_app.db.get_edge_by_labels(
                     doc["type"], edge_label, dst_label
                 )
@@ -696,8 +696,8 @@ class BcrClinicalXmlToJsonParser(object):
                 doc[edge_cls.__src_dst_assoc__] = {"id": xpath}
 
     def insert_edges_by_property(self, doc, root, edges, namespaces):
-        for edge_label, edge in edges.items():
-            for dst_label, dst_property in edge.items():
+        for edge_label, edge in list(edges.items()):
+            for dst_label, dst_property in list(edge.items()):
                 edge_cls = flask.current_app.db.get_edge_by_labels(
                     doc["type"], edge_label, dst_label
                 )
@@ -710,7 +710,7 @@ class BcrClinicalXmlToJsonParser(object):
 
     def insert_properties(self, doc, roots, properties, namespaces, schema):
         for root in roots:
-            for key, props in properties.items():
+            for key, props in list(properties.items()):
                 value = self.xpath(
                     root=root,
                     path=props["path"],

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -32,7 +32,7 @@ UNSUPPORTED_EXPORT_NODE_CATEGORIES = ["internal"]
 def _encode(val):
     """Encode keys or values for writing a tsv dict."""
     if isinstance(val, str):
-        return val.encode("utf-8")
+        return val
     elif not isinstance(val, str):
         return str(val)
     else:
@@ -650,11 +650,11 @@ class ExportFile(object):
             raise InternalError("Unable to determine file name with no results")
 
         if self.is_delimited and self.is_singular:
-            return "{}.{}".format(self.result.keys()[0], self.file_format)
+            return "{}.{}".format(list(self.result.keys())[0], self.file_format)
         elif self.is_delimited:
             return "gdc_export_{}.tar.gz".format(self._get_sha())
         elif self.is_json and self.is_singular:
-            return "{}.json".format(self.result.keys()[0])
+            return "{}.json".format(list(self.result.keys())[0])
         elif self.is_json:
             return "gdc_export_{}.json".format(self._get_sha())
         else:
@@ -695,7 +695,7 @@ class ExportFile(object):
         """Yield delimited string per result."""
         self.get_tabular()
         if self.is_singular:
-            yield self.result.values()[0].getvalue()
+            yield list(self.result.values())[0].getvalue()
         else:
             tar = tarfile.open(self.filename, mode="w|gz", fileobj=self)
             for label, entities in self.result.items():

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -51,9 +51,7 @@ def get_node_category(node_type):
     """
     cls = psqlgraph.Node.get_subclass(node_type)
     if cls is None:
-        raise UserError(
-            'Node type "{}" not found in dictionary'.format(node_type)
-        )
+        raise UserError('Node type "{}" not found in dictionary'.format(node_type))
     return cls._dictionary.get("category")
 
 

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -7,7 +7,7 @@ import copy
 import csv
 import hashlib
 import json
-import StringIO
+import io
 import tarfile
 import time
 
@@ -31,7 +31,7 @@ UNSUPPORTED_EXPORT_NODE_CATEGORIES = ["internal"]
 
 def _encode(val):
     """Encode keys or values for writing a tsv dict."""
-    if isinstance(val, unicode):
+    if isinstance(val, str):
         return val.encode("utf-8")
     elif not isinstance(val, str):
         return str(val)
@@ -73,13 +73,13 @@ def parse_ids(ids):
     if not ids:
         raise UserError("Please provide valid ids")
 
-    if isinstance(ids, (str, unicode)):
+    if isinstance(ids, str):
         ids = ids.split(",")
     elif not isinstance(ids, list):
         raise UserError("Invalid list of ids: {}".format(ids))
 
     # Assert that all entries in list are string or unicode
-    if not all(isinstance(id_, (str, unicode)) for id_ in ids):
+    if not all(isinstance(id_, str) for id_ in ids):
         raise UserError("Ids must be strings: {}".format(ids))
 
     return ids
@@ -110,7 +110,7 @@ def get_link_titles(entities, template):
         if link_count > 1:
             link_titles = (
                 get_link_name(split_link_alias(key)[0], column)
-                for column in xrange(link_count)
+                for column in range(link_count)
             )
             titles.extend(link_titles)
         else:
@@ -199,7 +199,7 @@ def get_node_link_json(node, props):
         else:
             links[edge_name] = [alias_root]
 
-    for edge_name, aliases in links.iteritems():
+    for edge_name, aliases in links.items():
         edges = getattr(node, edge_name, [])
         edge_aliases = [
             {
@@ -275,7 +275,7 @@ def entity_to_template_str(label, file_format, **kwargs):
     if file_format == "json":
         return json_dumps_formatted(template)
     elif file_format in DELIMITERS:
-        output = StringIO.StringIO()
+        output = io.StringIO()
         writer = csv.writer(output, delimiter=DELIMITERS[file_format])
         writer.writerow(template)
         writer.writerow(tsv_example_row(label, template))
@@ -310,7 +310,7 @@ def get_json_template(entity_types):
 
 def get_delimited_template(entity_types, file_format, filename=TEMPLATE_NAME):
     """Return :param:`file_format` (TSV or CSV) template for entity types."""
-    tar_obj = StringIO.StringIO()
+    tar_obj = io.StringIO()
     tar = tarfile.open(filename, mode="w|gz", fileobj=tar_obj)
 
     for entity_type in entity_types:
@@ -318,7 +318,7 @@ def get_delimited_template(entity_types, file_format, filename=TEMPLATE_NAME):
         partname = "{}.{}".format(entity_type, file_format)
         tarinfo = tarfile.TarInfo(name=partname)
         tarinfo.size = len(content)
-        tar.addfile(tarinfo, StringIO.StringIO(content))
+        tar.addfile(tarinfo, io.StringIO(content))
 
     tar.close()
     return tar_obj.getvalue()
@@ -334,7 +334,7 @@ def get_all_template(file_format, categories=None, exclude=None, **kwargs):
     exclude = exclude.split(",") if exclude else []
     entity_types = [
         entity_type
-        for entity_type, schema in dictionary.schema.iteritems()
+        for entity_type, schema in dictionary.schema.items()
         if "project_id" in schema.get("properties", {})
         and (not categories or schema["category"] in categories)
         and (not exclude or entity_type not in exclude)
@@ -557,7 +557,7 @@ class ExportFile(object):
         self.templates = dict()
         self.category = category
         self.get_nodes(ids, with_children)
-        self._buffer = StringIO.StringIO()
+        self._buffer = io.StringIO()
 
     def write(self, data):
         """Write data do internal buffer."""
@@ -578,7 +578,7 @@ class ExportFile(object):
     def reset(self):
         """Clear buffer."""
         self._buffer.close()
-        self._buffer = StringIO.StringIO()
+        self._buffer = io.StringIO()
 
     def get_nodes(self, ids, with_children):
         """Look up nodes and set self.result"""
@@ -650,11 +650,11 @@ class ExportFile(object):
             raise InternalError("Unable to determine file name with no results")
 
         if self.is_delimited and self.is_singular:
-            return "{}.{}".format(self.result.keys()[0], self.file_format)
+            return "{}.{}".format(list(self.result.keys())[0], self.file_format)
         elif self.is_delimited:
             return "gdc_export_{}.tar.gz".format(self._get_sha())
         elif self.is_json and self.is_singular:
-            return "{}.json".format(self.result.keys()[0])
+            return "{}.json".format(list(self.result.keys())[0])
         elif self.is_json:
             return "gdc_export_{}.json".format(self._get_sha())
         else:
@@ -675,35 +675,35 @@ class ExportFile(object):
         delimiter = DELIMITERS[self.file_format]
         json_output, self.result = self.result, {}
 
-        for label, entities in json_output.iteritems():
+        for label, entities in json_output.items():
             template = self.templates[label]
             template = [t.lstrip("*") for t in template]
             titles = []
             titles.extend(get_link_titles(entities, template))
             titles.extend(get_non_link_props(template))
-            buff = StringIO.StringIO()
+            buff = io.StringIO()
             writer = csv.DictWriter(buff, titles, delimiter=delimiter)
             self.result[label] = buff
             writer.writeheader()
 
             for tsv_dict in get_tsv_dicts(entities, titles):
                 writer.writerow(
-                    {_encode(k): _encode(v) for k, v in tsv_dict.iteritems()}
+                    {_encode(k): _encode(v) for k, v in tsv_dict.items()}
                 )
 
     def get_delimited_response(self):
         """Yield delimited string per result."""
         self.get_tabular()
         if self.is_singular:
-            yield self.result.values()[0].getvalue()
+            yield list(self.result.values())[0].getvalue()
         else:
             tar = tarfile.open(self.filename, mode="w|gz", fileobj=self)
-            for label, entities in self.result.iteritems():
+            for label, entities in self.result.items():
                 partname = "{}.{}".format(label, self.file_format)
                 info = tarfile.TarInfo(name=partname)
                 content = entities.getvalue()
                 info.size = len(content)
-                tar.addfile(info, StringIO.StringIO(content))
+                tar.addfile(info, io.StringIO(content))
                 yield self.getvalue()
                 self.reset()
             tar.close()
@@ -712,7 +712,7 @@ class ExportFile(object):
     def get_json_response(self):
         """Yield single json string."""
         # Throw away the keys because re-upload is not expecting them.
-        yield json_dumps_formatted([r for v in self.result.values() for r in v])
+        yield json_dumps_formatted([r for v in list(self.result.values()) for r in v])
 
     def get_response(self):
         """Return response based on format and number of results."""
@@ -896,7 +896,7 @@ def export_all(node_label, project_id, file_format, db, **kwargs):
         query_args = [cls] + linked_props
         query = session.query(*query_args).prop("project_id", project_id)
         # Join the related node tables using the links.
-        for link in cls._pg_links.values():
+        for link in list(cls._pg_links.values()):
             query = query.outerjoin(link["edge_out"]).outerjoin(link["dst_type"])
         # The result from the query should look like this (header just for
         # example):
@@ -921,7 +921,7 @@ def export_all(node_label, project_id, file_format, db, **kwargs):
                 row.append(val)
                 json_obj[prop] = val
             # Tack on the linked properties.
-            row.extend(map(lambda col: list_to_comma_string(col), result[1:]))
+            row.extend([list_to_comma_string(col) for col in result[1:]])
             for idx, title in enumerate(titles_linked):
                 json_obj["link_fields"][title] = result[idx + 1] or ""
             # Convert row elements to string if they are not

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -712,7 +712,7 @@ class ExportFile(object):
     def get_json_response(self):
         """Yield single json string."""
         # Throw away the keys because re-upload is not expecting them.
-        yield json_dumps_formatted([r for v in list(self.result.values()) for r in v])
+        yield json_dumps_formatted([r for v in self.result.values() for r in v])
 
     def get_response(self):
         """Return response based on format and number of results."""

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -881,7 +881,7 @@ def export_all(node_label, project_id, file_format, db, **kwargs):
         #
         # This is used to look up the classes for the linked nodes.
         # Now, fill out the properties lists from the titles.
-        for prop in map(format_prop, titles):
+        for prop in list(map(format_prop, titles)):
             if type(prop) is tuple:
                 link_name, link_prop = prop
                 link_cls = cls._pg_links[link_name]["dst_type"]

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -687,9 +687,7 @@ class ExportFile(object):
             writer.writeheader()
 
             for tsv_dict in get_tsv_dicts(entities, titles):
-                writer.writerow(
-                    {_encode(k): _encode(v) for k, v in tsv_dict.items()}
-                )
+                writer.writerow({_encode(k): _encode(v) for k, v in tsv_dict.items()})
 
     def get_delimited_response(self):
         """Yield delimited string per result."""

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -33,10 +33,8 @@ def _encode(val):
     """Encode keys or values for writing a tsv dict."""
     if isinstance(val, str):
         return val
-    elif not isinstance(val, str):
-        return str(val)
     else:
-        return val
+        return str(val)
 
 
 def get_node_category(node_type):

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -650,11 +650,11 @@ class ExportFile(object):
             raise InternalError("Unable to determine file name with no results")
 
         if self.is_delimited and self.is_singular:
-            return "{}.{}".format(list(self.result.keys())[0], self.file_format)
+            return "{}.{}".format(self.result.keys()[0], self.file_format)
         elif self.is_delimited:
             return "gdc_export_{}.tar.gz".format(self._get_sha())
         elif self.is_json and self.is_singular:
-            return "{}.json".format(list(self.result.keys())[0])
+            return "{}.json".format(self.result.keys()[0])
         elif self.is_json:
             return "gdc_export_{}.json".format(self._get_sha())
         else:
@@ -695,7 +695,7 @@ class ExportFile(object):
         """Yield delimited string per result."""
         self.get_tabular()
         if self.is_singular:
-            yield list(self.result.values())[0].getvalue()
+            yield self.result.values()[0].getvalue()
         else:
             tar = tarfile.open(self.filename, mode="w|gz", fileobj=self)
             for label, entities in self.result.items():
@@ -896,7 +896,7 @@ def export_all(node_label, project_id, file_format, db, **kwargs):
         query_args = [cls] + linked_props
         query = session.query(*query_args).prop("project_id", project_id)
         # Join the related node tables using the links.
-        for link in list(cls._pg_links.values()):
+        for link in cls._pg_links.values():
             query = query.outerjoin(link["edge_out"]).outerjoin(link["dst_type"])
         # The result from the query should look like this (header just for
         # example):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def encoded_jwt(iss):
         Return:
             str: JWT containing claims encoded with private key
         """
-        kid = JWT_KEYPAIR_FILES.keys()[0]
+        kid = list(JWT_KEYPAIR_FILES.keys())[0]
         scopes = ["openid"]
         token = utils.generate_signed_access_token(
             kid, private_key, user, 3600, scopes, iss=iss, forced_exp_time=None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,20 +121,27 @@ def mock_arborist_requests(request):
     def do_patch(authorized=True):
         def make_mock_response(*args, **kwargs):
             if not authorized:
-                raise AuthZError('Mocked Arborist says no')
+                raise AuthZError("Mocked Arborist says no")
             mocked_response = MagicMock(requests.Response)
             mocked_response.status_code = 200
 
             def mocked_get(*args, **kwargs):
                 return None
+
             mocked_response.get = mocked_get
 
             return mocked_response
 
         mocked_auth_request = MagicMock(side_effect=make_mock_response)
 
-        patch_auth_request = patch("gen3authz.client.arborist.client.ArboristClient.auth_request", mocked_auth_request)
-        patch_create_resource = patch("gen3authz.client.arborist.client.ArboristClient.create_resource", mocked_auth_request)
+        patch_auth_request = patch(
+            "gen3authz.client.arborist.client.ArboristClient.auth_request",
+            mocked_auth_request,
+        )
+        patch_create_resource = patch(
+            "gen3authz.client.arborist.client.ArboristClient.create_resource",
+            mocked_auth_request,
+        )
 
         patch_auth_request.start()
         patch_create_resource.start()

--- a/tests/integration/datadict/api.py
+++ b/tests/integration/datadict/api.py
@@ -137,19 +137,19 @@ ALIAS_HOST = "alias.sq3"
 
 INDEX_TABLES = {
     "index_record": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"rev", u"VARCHAR", 0, None, 0),
-        (2, u"form", u"VARCHAR", 0, None, 0),
-        (3, u"size", u"INTEGER", 0, None, 0),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "rev", "VARCHAR", 0, None, 0),
+        (2, "form", "VARCHAR", 0, None, 0),
+        (3, "size", "INTEGER", 0, None, 0),
     ],
     "index_record_hash": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"hash_type", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
-        (2, u"hash_value", u"VARCHAR", 0, None, 0),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "hash_type", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (2, "hash_value", "VARCHAR", 0, None, 0),
     ],
     "index_record_url": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"url", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "url", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
     ],
 }
 
@@ -157,21 +157,21 @@ INDEX_TABLES = {
 # pulled from indexd/tests/test_setup.py
 ALIAS_TABLES = {
     "alias_record": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"rev", u"VARCHAR", 0, None, 0),
-        (2, u"size", u"INTEGER", 0, None, 0),
-        (3, u"release", u"VARCHAR", 0, None, 0),
-        (4, u"metastring", u"VARCHAR", 0, None, 0),
-        (5, u"keeper_authority", u"VARCHAR", 0, None, 0),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "rev", "VARCHAR", 0, None, 0),
+        (2, "size", "INTEGER", 0, None, 0),
+        (3, "release", "VARCHAR", 0, None, 0),
+        (4, "metastring", "VARCHAR", 0, None, 0),
+        (5, "keeper_authority", "VARCHAR", 0, None, 0),
     ],
     "alias_record_hash": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"hash_type", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
-        (2, u"hash_value", u"VARCHAR", 0, None, 0),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "hash_type", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (2, "hash_value", "VARCHAR", 0, None, 0),
     ],
     "alias_record_host_authority": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"host", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "host", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
     ],
 }
 

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -27,6 +27,7 @@ from sheepdog.test_settings import (
 from tests import utils
 from tests.integration.datadict.api import app as _app, app_init, indexd_init
 from tests.integration.datadict.submission.test_endpoints import put_cgci_blgsp
+import imp
 
 try:
     reload  # Python 2.7
@@ -91,7 +92,7 @@ def app(tmpdir, request):
     dictionary_setup(_app)
     # this is to make sure sqlite is initialized
     # for every unit test
-    reload(default_settings)
+    imp.reload(default_settings)
 
     # fresh files before running
     for filename in ['auth.sq3', 'index.sq3', 'alias.sq3']:
@@ -173,7 +174,7 @@ def index_client():
 
 
 def dictionary_setup(_app):
-    print 'dictionary setup'
+    print('dictionary setup')
     url = 's3://testurl'
     session = requests.Session()
     adapter = requests_mock.Adapter()

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -29,15 +29,6 @@ from tests.integration.datadict.api import app as _app, app_init, indexd_init
 from tests.integration.datadict.submission.test_endpoints import put_cgci_blgsp
 import importlib
 
-try:
-    reload  # Python 2.7
-except NameError:
-    try:
-        from importlib import reload  # Python 3.4+
-    except ImportError:
-        from imp import reload  # Python 3.0 - 3.3
-
-
 def get_parent(path):
     print(path)
     return path[0 : path.rfind("/")]

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -35,38 +35,40 @@ except NameError:
     try:
         from importlib import reload  # Python 3.4+
     except ImportError:
-        from imp import reload # Python 3.0 - 3.3
+        from imp import reload  # Python 3.0 - 3.3
+
 
 def get_parent(path):
     print(path)
-    return path[0:path.rfind('/')]
+    return path[0 : path.rfind("/")]
 
-PATH_TO_SCHEMA_DIR = get_parent(os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir))) + '/datadict/schemas'
+
+PATH_TO_SCHEMA_DIR = (
+    get_parent(os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir)))
+    + "/datadict/schemas"
+)
+
 
 def pg_config():
-    test_host = 'localhost'
-    test_user = 'test'
-    test_pass = 'test'
-    test_db = 'sheepdog_automated_test'
-    return dict(
-        host=test_host,
-        user=test_user,
-        password=test_pass,
-        database=test_db,
-    )
+    test_host = "localhost"
+    test_user = "test"
+    test_pass = "test"
+    test_db = "sheepdog_automated_test"
+    return dict(host=test_host, user=test_user, password=test_pass, database=test_db,)
 
 
 @pytest.fixture
 def require_index_exists_on(app, monkeypatch):
-    monkeypatch.setitem(app.config, 'REQUIRE_FILE_INDEX_EXISTS', True)
+    monkeypatch.setitem(app.config, "REQUIRE_FILE_INDEX_EXISTS", True)
+
 
 @pytest.fixture
 def require_index_exists_off(app, monkeypatch):
-    monkeypatch.setitem(app.config, 'REQUIRE_FILE_INDEX_EXISTS', False)
+    monkeypatch.setitem(app.config, "REQUIRE_FILE_INDEX_EXISTS", False)
 
 
 def wait_for_indexd_alive(port):
-    url = 'http://localhost:{}/_status'.format(port)
+    url = "http://localhost:{}/_status".format(port)
     try:
         requests.get(url)
     except requests.ConnectionError:
@@ -76,7 +78,7 @@ def wait_for_indexd_alive(port):
 
 
 def wait_for_indexd_not_alive(port):
-    url = 'http://localhost:{}/_status'.format(port)
+    url = "http://localhost:{}/_status".format(port)
     try:
         requests.get(url)
     except requests.ConnectionError:
@@ -95,26 +97,30 @@ def app(tmpdir, request):
     importlib.reload(default_settings)
 
     # fresh files before running
-    for filename in ['auth.sq3', 'index.sq3', 'alias.sq3']:
+    for filename in ["auth.sq3", "index.sq3", "alias.sq3"]:
         if os.path.exists(filename):
             os.remove(filename)
     indexd_app = get_indexd_app()
 
-    indexd_init(*INDEX_CLIENT['auth'])
-    indexd = Process(target=indexd_app.run, args=['localhost', port])
+    indexd_init(*INDEX_CLIENT["auth"])
+    indexd = Process(target=indexd_app.run, args=["localhost", port])
     indexd.start()
     wait_for_indexd_alive(port)
 
     gencode_json = tmpdir.mkdir("slicing").join("test_gencode.json")
-    gencode_json.write(json.dumps({
-        'a_gene': ['chr1', None, 200],
-        'b_gene': ['chr1', 150,  300],
-        'c_gene': ['chr1', 200,  None],
-        'd_gene': ['chr1', None, None],
-    }))
+    gencode_json.write(
+        json.dumps(
+            {
+                "a_gene": ["chr1", None, 200],
+                "b_gene": ["chr1", 150, 300],
+                "c_gene": ["chr1", 200, None],
+                "d_gene": ["chr1", None, None],
+            }
+        )
+    )
 
     def teardown():
-        for filename in ['auth.sq3', 'index.sq3', 'alias.sq3']:
+        for filename in ["auth.sq3", "index.sq3", "alias.sq3"]:
             if os.path.exists(filename):
                 os.remove(filename)
 
@@ -130,9 +136,13 @@ def app(tmpdir, request):
 
     _app.logger.setLevel(os.environ.get("GDC_LOG_LEVEL", "WARNING"))
 
-    _app.jwt_public_keys = {_app.config['USER_API']: {
-            'key-test': utils.read_file('./integration/resources/keys/test_public_key.pem')
-    }}
+    _app.jwt_public_keys = {
+        _app.config["USER_API"]: {
+            "key-test": utils.read_file(
+                "./integration/resources/keys/test_public_key.pem"
+            )
+        }
+    }
 
     _app.auth = ArboristClient()
 
@@ -147,16 +157,16 @@ def pg_driver(request, client):
         with pg_driver.engine.begin() as conn:
             for table in models.Node().get_subclass_table_names():
                 if table != models.Node.__tablename__:
-                    conn.execute('delete from {}'.format(table))
+                    conn.execute("delete from {}".format(table))
             for table in models.Edge().get_subclass_table_names():
                 if table != models.Edge.__tablename__:
-                    conn.execute('delete from {}'.format(table))
-            conn.execute('delete from versioned_nodes')
-            conn.execute('delete from _voided_nodes')
-            conn.execute('delete from _voided_edges')
-            conn.execute('delete from transaction_snapshots')
-            conn.execute('delete from transaction_documents')
-            conn.execute('delete from transaction_logs')
+                    conn.execute("delete from {}".format(table))
+            conn.execute("delete from versioned_nodes")
+            conn.execute("delete from _voided_nodes")
+            conn.execute("delete from _voided_edges")
+            conn.execute("delete from transaction_snapshots")
+            conn.execute("delete from transaction_documents")
+            conn.execute("delete from transaction_logs")
 
     tearDown()
     request.addfinalizer(tearDown)
@@ -170,24 +180,27 @@ def cgci_blgsp(client, admin):
 
 @pytest.fixture()
 def index_client():
-    return IndexClient(INDEX_CLIENT['host'], INDEX_CLIENT['version'], INDEX_CLIENT['auth'])
+    return IndexClient(
+        INDEX_CLIENT["host"], INDEX_CLIENT["version"], INDEX_CLIENT["auth"]
+    )
 
 
 def dictionary_setup(_app):
-    print('dictionary setup')
-    url = 's3://testurl'
+    print("dictionary setup")
+    url = "s3://testurl"
     session = requests.Session()
     adapter = requests_mock.Adapter()
-    session.mount('s3', adapter)
-    json_dict = json.load(open(PATH_TO_SCHEMA_DIR + '/dictionary.json'))
-    adapter.register_uri('GET', url, json=json_dict, status_code=200)
+    session.mount("s3", adapter)
+    json_dict = json.load(open(PATH_TO_SCHEMA_DIR + "/dictionary.json"))
+    adapter.register_uri("GET", url, json=json_dict, status_code=200)
     resp = session.get(url)
 
-    with patch('requests.get') as get_mocked:
+    with patch("requests.get") as get_mocked:
         get_mocked.return_value = resp
         datadictionary = DataDictionary(url=url)
         dictionary.init(datadictionary)
         from gdcdatamodel import models as md
         from gdcdatamodel import validators as vd
+
         models.init(md)
         validators.init(vd)

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -27,7 +27,7 @@ from sheepdog.test_settings import (
 from tests import utils
 from tests.integration.datadict.api import app as _app, app_init, indexd_init
 from tests.integration.datadict.submission.test_endpoints import put_cgci_blgsp
-import imp
+import importlib
 
 try:
     reload  # Python 2.7
@@ -92,7 +92,7 @@ def app(tmpdir, request):
     dictionary_setup(_app)
     # this is to make sure sqlite is initialized
     # for every unit test
-    imp.reload(default_settings)
+    importlib.reload(default_settings)
 
     # fresh files before running
     for filename in ['auth.sq3', 'index.sq3', 'alias.sq3']:
@@ -191,4 +191,3 @@ def dictionary_setup(_app):
         from gdcdatamodel import validators as vd
         models.init(md)
         validators.init(vd)
-

--- a/tests/integration/datadict/submission/test_admin_endpoints.py
+++ b/tests/integration/datadict/submission/test_admin_endpoints.py
@@ -9,7 +9,7 @@ import pytest
 
 from datamodelutils import models as md
 from tests.integration.datadict.submission.test_endpoints import (
-    post_example_entities_together
+    post_example_entities_together,
 )
 from tests.integration.datadict.submission.utils import data_fnames
 

--- a/tests/integration/datadict/submission/test_bcr_xml_to_json.py
+++ b/tests/integration/datadict/submission/test_bcr_xml_to_json.py
@@ -18,7 +18,7 @@ def test_gdc_type_mappings():
 
     # parse long
     long_val = munge_property("3111118", "long")
-    assert isinstance(long_val, long)
+    assert isinstance(long_val, int)
     with pytest.raises(ValueError):
         munge_property("4.9", "long")
 

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -25,10 +25,10 @@ from sheepdog.utils import get_external_proxies
 from sheepdog.utils.transforms import TSVToJSONConverter
 from tests.integration.datadict.submission.utils import data_fnames
 
-BLGSP_PATH = '/v0/submission/CGCI/BLGSP/'
-BRCA_PATH = '/v0/submission/TCGA/BRCA/'
+BLGSP_PATH = "/v0/submission/CGCI/BLGSP/"
+BRCA_PATH = "/v0/submission/TCGA/BRCA/"
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
 
 @contextlib.contextmanager
@@ -37,7 +37,7 @@ def s3_conn():
     mock.start(reset=False)
     conn = boto.connect_s3()
     yield conn
-    bucket = conn.get_bucket('test_submission')
+    bucket = conn.get_bucket("test_submission")
     for part in bucket.list_multipart_uploads():
         part.cancel_upload()
     mock.stop()
@@ -48,7 +48,7 @@ def mock_request(f):
         mock = mock_s3()
         mock.start(reset=False)
         conn = boto.connect_s3()
-        conn.create_bucket('test_submission')
+        conn.create_bucket("test_submission")
 
         result = f(*args, **kwargs)
         mock.stop()
@@ -58,12 +58,11 @@ def mock_request(f):
 
 
 def put_cgci(client, auth=None):
-    path = '/v0/submission'
+    path = "/v0/submission"
     headers = auth
-    data = json.dumps({
-        'name': 'CGCI', 'type': 'program',
-        'dbgap_accession_number': 'phs000235'
-    })
+    data = json.dumps(
+        {"name": "CGCI", "type": "program", "dbgap_accession_number": "phs000235"}
+    )
     r = client.put(path, headers=headers, data=data)
     return r
 
@@ -72,15 +71,17 @@ def put_cgci_blgsp(client, auth=None):
     r = put_cgci(client, auth=auth)
     assert r.status_code == 200, r.data
 
-    path = '/v0/submission/CGCI/'
+    path = "/v0/submission/CGCI/"
     headers = auth
-    data = json.dumps({
-        "type": "project",
-        "code": "BLGSP",
-        "dbgap_accession_number": 'phs000527',
-        "name": "Burkitt Lymphoma Genome Sequencing Project",
-        "state": "open"
-    })
+    data = json.dumps(
+        {
+            "type": "project",
+            "code": "BLGSP",
+            "dbgap_accession_number": "phs000527",
+            "name": "Burkitt Lymphoma Genome Sequencing Project",
+            "state": "open",
+        }
+    )
     r = client.put(path, headers=headers, data=data)
     assert r.status_code == 200, r.data
     del g.user
@@ -89,21 +90,22 @@ def put_cgci_blgsp(client, auth=None):
 
 def put_tcga_brca(client, submitter):
     headers = submitter
-    data = json.dumps({
-        'name': 'TCGA', 'type': 'program',
-        'dbgap_accession_number': 'phs000178'
-    })
-    r = client.put('/v0/submission/', headers=headers, data=data)
+    data = json.dumps(
+        {"name": "TCGA", "type": "program", "dbgap_accession_number": "phs000178"}
+    )
+    r = client.put("/v0/submission/", headers=headers, data=data)
     assert r.status_code == 200, r.data
     headers = submitter
-    data = json.dumps({
-        "type": "project",
-        "code": "BRCA",
-        "name": "TEST",
-        "dbgap_accession_number": "phs000178",
-        "state": "open"
-    })
-    r = client.put('/v0/submission/TCGA/', headers=headers, data=data)
+    data = json.dumps(
+        {
+            "type": "project",
+            "code": "BRCA",
+            "name": "TEST",
+            "dbgap_accession_number": "phs000178",
+            "state": "open",
+        }
+    )
+    r = client.put("/v0/submission/TCGA/", headers=headers, data=data)
     assert r.status_code == 200, r.data
     del g.user
     return r
@@ -113,21 +115,22 @@ def test_program_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci(client, auth=admin)
     assert resp.status_code == 200, resp.data
     print(resp.data)
-    resp = client.get('/v0/submission/')
-    assert resp.json['links'] == ['/v0/submission/CGCI'], resp.json
+    resp = client.get("/v0/submission/")
+    assert resp.json["links"] == ["/v0/submission/CGCI"], resp.json
 
 
 def test_program_creation_without_admin_token(client, pg_driver, submitter):
-    path = '/v0/submission/'
+    path = "/v0/submission/"
     headers = submitter
-    data = json.dumps({'name': 'CGCI', 'type': 'program'})
+    data = json.dumps({"name": "CGCI", "type": "program"})
     resp = client.put(path, headers=headers, data=data)
     assert resp.status_code == 403
 
 
 def test_program_creation_endpoint_for_program_not_supported(
-        client, pg_driver, submitter):
-    path = '/v0/submission/abc/'
+    client, pg_driver, submitter
+):
+    path = "/v0/submission/abc/"
     resp = client.post(path, headers=submitter)
     assert resp.status_code == 404
 
@@ -135,91 +138,96 @@ def test_program_creation_endpoint_for_program_not_supported(
 def test_project_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci_blgsp(client, auth=admin)
     assert resp.status_code == 200
-    resp = client.get('/v0/submission/CGCI/')
+    resp = client.get("/v0/submission/CGCI/")
     with pg_driver.session_scope():
         assert pg_driver.nodes(md.Project).count() == 1
-        n_cgci = (
-            pg_driver.nodes(md.Project)
-            .path('programs')
-            .props(name='CGCI')
-            .count()
-        )
+        n_cgci = pg_driver.nodes(md.Project).path("programs").props(name="CGCI").count()
         assert n_cgci == 1
-    assert resp.json['links'] == ['/v0/submission/CGCI/BLGSP'], resp.json
+    assert resp.json["links"] == ["/v0/submission/CGCI/BLGSP"], resp.json
 
 
 def test_project_creation_without_admin_token(client, pg_driver, submitter, admin):
     put_cgci(client, admin)
-    path = '/v0/submission/CGCI/'
+    path = "/v0/submission/CGCI/"
     resp = client.put(
-        path, headers=submitter, data=json.dumps({
-            "type": "project",
-            "code": "BLGSP",
-            "dbgap_accession_number": "phs000527",
-            "name": "Burkitt Lymphoma Genome Sequencing Project",
-            "state": "open"}))
+        path,
+        headers=submitter,
+        data=json.dumps(
+            {
+                "type": "project",
+                "code": "BLGSP",
+                "dbgap_accession_number": "phs000527",
+                "name": "Burkitt Lymphoma Genome Sequencing Project",
+                "state": "open",
+            }
+        ),
+    )
     assert resp.status_code == 403
 
 
 def test_put_entity_creation_valid(client, pg_driver, cgci_blgsp, submitter):
     headers = submitter
-    data = json.dumps({
-        "type": "experiment",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    data = json.dumps(
+        {
+            "type": "experiment",
+            "submitter_id": "BLGSP-71-06-00019",
+            "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 200, resp.data
 
 
 def test_unauthenticated_post(client, pg_driver, cgci_blgsp, submitter):
     # send garbage token
-    headers = {'Authorization': 'test'}
-    data = json.dumps({
-        "type": "case",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    headers = {"Authorization": "test"}
+    data = json.dumps(
+        {
+            "type": "case",
+            "submitter_id": "BLGSP-71-06-00019",
+            "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.post(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 401
 
 
-def test_unauthorized_post(client, pg_driver, cgci_blgsp, submitter, mock_arborist_requests):
+def test_unauthorized_post(
+    client, pg_driver, cgci_blgsp, submitter, mock_arborist_requests
+):
     headers = submitter
     mock_arborist_requests(authorized=False)
     resp = client.post(
-        BLGSP_PATH, headers=headers, data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        BLGSP_PATH,
+        headers=headers,
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     assert resp.status_code == 403
 
 
 def test_put_valid_entity_missing_target(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, 'sample.json'), 'r') as f:
+    with open(os.path.join(DATA_DIR, "sample.json"), "r") as f:
         sample = json.loads(f.read())
-        sample['cases'] = {"submitter_id": "missing-case"}
+        sample["cases"] = {"submitter_id": "missing-case"}
 
-    r = client.put(
-        BLGSP_PATH,
-        headers=submitter,
-        data=json.dumps(sample)
-    )
+    r = client.put(BLGSP_PATH, headers=submitter, data=json.dumps(sample))
 
     print(r.data)
     assert r.status_code == 400, r.data
-    assert r.status_code == r.json['code']
-    assert r.json['entities'][0]['errors'][0]['keys'] == ['cases'], r.json['entities'][0]['errors']
-    assert r.json['entities'][0]['errors'][0]['type'] == 'INVALID_LINK'
+    assert r.status_code == r.json["code"]
+    assert r.json["entities"][0]["errors"][0]["keys"] == ["cases"], r.json["entities"][
+        0
+    ]["errors"]
+    assert r.json["entities"][0]["errors"][0]["type"] == "INVALID_LINK"
     assert (
         "[{'project_id': 'CGCI-BLGSP', 'submitter_id': 'missing-case'}]"
-        in r.json['entities'][0]['errors'][0]['message']
+        in r.json["entities"][0]["errors"][0]["message"]
     )
 
 
@@ -227,53 +235,46 @@ def test_put_valid_entity_invalid_type(client, pg_driver, cgci_blgsp, submitter)
     r = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps([
-            {
-                "type": "experiment",
-                "submitter_id": "BLGSP-71-06-00019",
-                "projects": {
-                    "code": "BLGSP"
-                }
-            },
-            {
-                "type": "case",
-                "submitter_id": "BLGSP-71-case-01",
-                "experiments": {
-                    "submitter_id": 'BLGSP-71-06-00019'
-                }
-            },
-            {
-                'type': "demographic",
-                'ethnicity': 'not reported',
-                'gender': 'male',
-                'race': 'asian',
-                'submitter_id': 'demographic1',
-                'year_of_birth': '1900',
-                'year_of_death': 2000,
-                'cases': {
-                    'submitter_id': 'BLGSP-71-case-01'
-                }
-            }
-        ]))
+        data=json.dumps(
+            [
+                {
+                    "type": "experiment",
+                    "submitter_id": "BLGSP-71-06-00019",
+                    "projects": {"code": "BLGSP"},
+                },
+                {
+                    "type": "case",
+                    "submitter_id": "BLGSP-71-case-01",
+                    "experiments": {"submitter_id": "BLGSP-71-06-00019"},
+                },
+                {
+                    "type": "demographic",
+                    "ethnicity": "not reported",
+                    "gender": "male",
+                    "race": "asian",
+                    "submitter_id": "demographic1",
+                    "year_of_birth": "1900",
+                    "year_of_death": 2000,
+                    "cases": {"submitter_id": "BLGSP-71-case-01"},
+                },
+            ]
+        ),
+    )
 
     print(r.json)
     assert r.status_code == 400, r.data
-    assert r.status_code == r.json['code']
-    assert (r.json['entities'][2]['errors'][0]['keys']
-            == ['year_of_birth']), r.data
-    assert (r.json['entities'][2]['errors'][0]['type']
-            == 'INVALID_VALUE'), r.data
+    assert r.status_code == r.json["code"]
+    assert r.json["entities"][2]["errors"][0]["keys"] == ["year_of_birth"], r.data
+    assert r.json["entities"][2]["errors"][0]["type"] == "INVALID_VALUE", r.data
 
 
 def test_post_example_entities(client, pg_driver, cgci_blgsp, submitter):
     path = BLGSP_PATH
-    with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
-        case_sid = json.loads(f.read())['submitter_id']
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
     for fname in data_fnames:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
-            resp = client.post(
-                path, headers=submitter, data=f.read()
-            )
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
+            resp = client.post(path, headers=submitter, data=f.read())
             assert resp.status_code == 201, resp.data
 
 
@@ -283,7 +284,7 @@ def post_example_entities_together(client, submitter, data_fnames2=None):
     path = BLGSP_PATH
     data = []
     for fname in data_fnames2:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
             data.append(json.loads(f.read()))
     return client.post(path, headers=submitter, data=json.dumps(data))
 
@@ -292,71 +293,74 @@ def put_example_entities_together(client, headers):
     path = BLGSP_PATH
     data = []
     for fname in data_fnames:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
             data.append(json.loads(f.read()))
     return client.put(path, headers=headers, data=json.dumps(data))
 
 
 def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
-        case_sid = json.loads(f.read())['submitter_id']
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
     resp = post_example_entities_together(client, submitter)
     print(resp.data)
     assert resp.status_code == 201, resp.data
 
 
 def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary')
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary")
     print(resp.data)
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/slide" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/case" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/aliquot" \
-           in json.loads(resp.data)['links']
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/slide" in json.loads(resp.data)["links"]
+    )
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/case" in json.loads(resp.data)["links"]
+    )
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/aliquot"
+        in json.loads(resp.data)["links"]
+    )
 
 
 def test_top_level_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/_dictionary')
+    resp = client.get("/v0/submission/_dictionary")
     print(resp.data)
-    assert "/v0/submission/_dictionary/slide" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/_dictionary/case" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/_dictionary/aliquot" \
-           in json.loads(resp.data)['links']
+    assert "/v0/submission/_dictionary/slide" in json.loads(resp.data)["links"]
+    assert "/v0/submission/_dictionary/case" in json.loads(resp.data)["links"]
+    assert "/v0/submission/_dictionary/aliquot" in json.loads(resp.data)["links"]
 
 
 def test_dictionary_get_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary/aliquot')
-    assert json.loads(resp.data)['id'] == 'aliquot'
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary/aliquot")
+    assert json.loads(resp.data)["id"] == "aliquot"
 
 
 def test_top_level_dictionary_get_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/_dictionary/aliquot')
-    assert json.loads(resp.data)['id'] == 'aliquot'
+    resp = client.get("/v0/submission/_dictionary/aliquot")
+    assert json.loads(resp.data)["id"] == "aliquot"
 
 
 def test_dictionary_get_definitions(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary/_definitions')
-    assert 'UUID' in resp.json
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary/_definitions")
+    assert "UUID" in resp.json
 
 
 def test_put_dry_run(client, pg_driver, cgci_blgsp, submitter):
-    path = '/v0/submission/CGCI/BLGSP/_dry_run/'
+    path = "/v0/submission/CGCI/BLGSP/_dry_run/"
     resp = client.put(
         path,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     assert resp.status_code == 200, resp.data
     resp_json = json.loads(resp.data)
-    assert resp_json['entity_error_count'] == 0
-    assert resp_json['created_entity_count'] == 1
+    assert resp_json["entity_error_count"] == 0
+    assert resp_json["created_entity_count"] == 1
     with pg_driver.session_scope():
         assert not pg_driver.nodes(md.Experiment).first()
 
@@ -366,28 +370,31 @@ def test_incorrect_project_error(client, pg_driver, cgci_blgsp, submitter, admin
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     resp = client.put(
         BRCA_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     resp_json = json.loads(resp.data)
     assert resp.status_code == 400
-    assert resp_json['code'] == 400
-    assert resp_json['entity_error_count'] == 1
-    assert resp_json['created_entity_count'] == 0
-    assert (resp_json['entities'][0]['errors'][0]['type']
-            == 'INVALID_PERMISSIONS')
+    assert resp_json["code"] == 400
+    assert resp_json["entity_error_count"] == 1
+    assert resp_json["created_entity_count"] == 0
+    assert resp_json["entities"][0]["errors"][0]["type"] == "INVALID_PERMISSIONS"
 
 
 def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
@@ -399,7 +406,9 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
         assert ct is not None, case.props
 
 
-def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submitter, admin):
+def test_disallow_cross_project_references(
+    client, pg_driver, cgci_blgsp, submitter, admin
+):
     put_tcga_brca(client, admin)
     data = {
         "progression_or_recurrence": "unknown",
@@ -416,18 +425,13 @@ def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submit
         "age_at_diagnosis": 47,
         "vital_status": "dead",
         "morphology": "8255/3",
-        "cases": {
-            "submitter_id": "BLGSP-71-06-00019"
-        },
+        "cases": {"submitter_id": "BLGSP-71-06-00019"},
         "type": "diagnosis",
         "prior_malignancy": "no",
         "days_to_recurrence": -1,
-        "days_to_last_known_disease_status": -1
+        "days_to_last_known_disease_status": -1,
     }
-    resp = client.put(
-        BRCA_PATH,
-        headers=submitter,
-        data=json.dumps(data))
+    resp = client.put(BRCA_PATH, headers=submitter, data=json.dumps(data))
     assert resp.status_code == 400, resp.data
 
 
@@ -435,15 +439,17 @@ def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     assert resp.status_code == 200, resp.data
-    did = resp.json['entities'][0]['id']
-    path = BLGSP_PATH + 'entities/' + did
+    did = resp.json["entities"][0]["id"]
+    path = BLGSP_PATH + "entities/" + did
     resp = client.delete(path, headers=submitter)
     assert resp.status_code == 200, resp.data
 
@@ -455,12 +461,12 @@ def test_catch_internal_errors(monkeypatch, client, pg_driver, cgci_blgsp, submi
     """
 
     def just_raise_exception(self):
-        raise Exception('test')
+        raise Exception("test")
 
-    monkeypatch.setattr(UploadTransaction, 'pre_validate', just_raise_exception)
+    monkeypatch.setattr(UploadTransaction, "pre_validate", just_raise_exception)
     try:
         r = put_example_entities_together(client, submitter)
-        assert len(r.json['transactional_errors']) == 1, r.data
+        assert len(r.json["transactional_errors"]) == 1, r.data
     except:
         raise
 
@@ -471,23 +477,21 @@ def test_validator_error_types(client, pg_driver, cgci_blgsp, submitter):
     r = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "sample",
-            "cases": {
-                "submitter_id": "BLGSP-71-06-00019"
-            },
-            "is_ffpe": "maybe",
-            "sample_type": "Blood Derived Normal",
-            "submitter_id": "BLGSP-71-06-00019",
-            "longest_dimension": -1.0
-        }))
-    errors = {
-        e['keys'][0]: e['type']
-        for e in r.json['entities'][0]['errors']
-    }
+        data=json.dumps(
+            {
+                "type": "sample",
+                "cases": {"submitter_id": "BLGSP-71-06-00019"},
+                "is_ffpe": "maybe",
+                "sample_type": "Blood Derived Normal",
+                "submitter_id": "BLGSP-71-06-00019",
+                "longest_dimension": -1.0,
+            }
+        ),
+    )
+    errors = {e["keys"][0]: e["type"] for e in r.json["entities"][0]["errors"]}
     assert r.status_code == 400, r.data
-    assert errors['is_ffpe'] == 'INVALID_VALUE'
-    assert errors['longest_dimension'] == 'INVALID_VALUE'
+    assert errors["is_ffpe"] == "INVALID_VALUE"
+    assert errors["longest_dimension"] == "INVALID_VALUE"
 
 
 def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
@@ -497,21 +501,21 @@ def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
         data="""{
     "key1": "valid value",
     "key2": not a string,
-}""")
+}""",
+    )
     print(resp.data)
     assert resp.status_code == 400
-    assert 'Expecting value' in resp.json['message']
+    assert "Expecting value" in resp.json["message"]
+
 
 def test_get_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
     post_example_entities_together(client, submitter)
     with pg_driver.session_scope():
         case_id = pg_driver.nodes(md.Case).first().node_id
-    path = '/v0/submission/CGCI/BLGSP/entities/{case_id}'.format(case_id=case_id)
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/entities/{case_id}".format(case_id=case_id)
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.json['entities'][0]['properties']['id'] == case_id, r.data
+    assert r.json["entities"][0]["properties"]["id"] == case_id, r.data
 
 
 def test_invalid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter):
@@ -519,31 +523,37 @@ def test_invalid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitte
     Test that submitting an invalid data file doesn't create an index and an
     alias.
     """
+
     def fail_index_test(_):
-        raise AssertionError('IndexClient tried to create index or alias')
+        raise AssertionError("IndexClient tried to create index or alias")
 
     # Since the IndexClient should never be called to register anything if the
     # file is invalid, change the ``create`` and ``create_alias`` methods to
     # raise an error.
     monkeypatch.setattr(
-        UploadTransaction, 'index_client.create', fail_index_test, raising=False
+        UploadTransaction, "index_client.create", fail_index_test, raising=False
     )
     monkeypatch.setattr(
-        UploadTransaction, 'index_client.create_alias', fail_index_test,
-        raising=False
+        UploadTransaction, "index_client.create_alias", fail_index_test, raising=False
     )
     # Attempt to post the invalid entities.
-    test_fnames = (
-        data_fnames
-        + ['read_group.json', 'submitted_unaligned_reads_invalid.json']
-    )
-    resp = post_example_entities_together(
-        client, submitter, data_fnames2=test_fnames
-    )
+    test_fnames = data_fnames + [
+        "read_group.json",
+        "submitted_unaligned_reads_invalid.json",
+    ]
+    resp = post_example_entities_together(client, submitter, data_fnames2=test_fnames)
     print(resp)
 
 
-def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter, index_client, require_index_exists_off):
+def test_valid_file_index(
+    monkeypatch,
+    client,
+    pg_driver,
+    cgci_blgsp,
+    submitter,
+    index_client,
+    require_index_exists_off,
+):
     """
     Test that submitting a valid data file creates an index and an alias.
     """
@@ -552,23 +562,18 @@ def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter,
     # called.
 
     # Attempt to post the valid entities.
-    test_fnames = (
-        data_fnames
-        + ['read_group.json', 'submitted_unaligned_reads.json']
-    )
-    resp = post_example_entities_together(
-        client, submitter, data_fnames2=test_fnames
-    )
+    test_fnames = data_fnames + ["read_group.json", "submitted_unaligned_reads.json"]
+    resp = post_example_entities_together(client, submitter, data_fnames2=test_fnames)
     assert resp.status_code == 201, resp.data
 
     # this is a node that will have an indexd entry
     sur_entity = None
-    for entity in resp.json['entities']:
-        if entity['type'] == 'submitted_unaligned_reads':
+    for entity in resp.json["entities"]:
+        if entity["type"] == "submitted_unaligned_reads":
             sur_entity = entity
 
-    assert sur_entity, 'No submitted_unaligned_reads entity created'
-    assert index_client.get(sur_entity['id']), 'No indexd document created'
+    assert sur_entity, "No submitted_unaligned_reads entity created"
+    assert index_client.get(sur_entity["id"]), "No indexd document created"
 
 
 def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
@@ -579,13 +584,12 @@ def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
     data = {
         "type": "experiment",
         "submitter_id": "BLGSP-71-06-00019",
-        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
     }
 
     # convert to TSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/experiment_tmp.tsv"
+        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
@@ -596,7 +600,7 @@ def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     headers = submitter
@@ -613,13 +617,12 @@ def test_submit_valid_csv(client, pg_driver, cgci_blgsp, submitter):
     data = {
         "type": "experiment",
         "submitter_id": "BLGSP-71-06-00019",
-        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
     }
 
     # convert to CSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/experiment_tmp.csv"
+        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.csv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter=",")
@@ -630,7 +633,7 @@ def test_submit_valid_csv(client, pg_driver, cgci_blgsp, submitter):
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     headers = submitter
@@ -645,13 +648,13 @@ def test_can_submit_with_asterisk_json(client, pg_driver, cgci_blgsp, submitter)
     """
 
     headers = submitter
-    data = json.dumps({
-        "*type": "experiment",
-        "*submitter_id": "BLGSP-71-06-00019",
-        "*projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    data = json.dumps(
+        {
+            "*type": "experiment",
+            "*submitter_id": "BLGSP-71-06-00019",
+            "*projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 200, resp.data
 
@@ -664,12 +667,11 @@ def test_can_submit_with_asterisk_tsv(client, pg_driver, cgci_blgsp, submitter):
     data = {
         "*type": "experiment",
         "*submitter_id": "BLGSP-71-06-00019",
-        "*projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+        "*projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
     }
     # convert to TSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/experiment_tmp.tsv"
+        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
@@ -680,7 +682,7 @@ def test_can_submit_with_asterisk_tsv(client, pg_driver, cgci_blgsp, submitter):
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     headers = submitter
@@ -693,20 +695,16 @@ def test_export_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
     post_example_entities_together(client, submitter)
     with pg_driver.session_scope():
         case_id = pg_driver.nodes(md.Case).first().node_id
-    path = '/v0/submission/CGCI/BLGSP/export/?ids={case_id}'.format(case_id=case_id)
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?ids={case_id}".format(case_id=case_id)
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
+    assert r.headers["Content-Disposition"].endswith("tsv")
 
-    path += '&format=json'
-    r = client.get(
-        path,
-        headers=submitter)
+    path += "&format=json"
+    r = client.get(path, headers=submitter)
     data = r.json
     assert data and len(data) == 1
-    assert data[0]['id'] == case_id
+    assert data[0]["id"] == case_id
 
 
 def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
@@ -715,16 +713,14 @@ def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
         case = pg_driver.nodes(md.Case).first()
         new_case = md.Case(str(uuid.uuid4()))
         new_case.props = case.props
-        new_case.submitter_id = 'case-2'
+        new_case.submitter_id = "case-2"
         s.add(new_case)
         case_count = pg_driver.nodes(md.Case).count()
-    path = '/v0/submission/CGCI/BLGSP/export/?node_label=case'
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?node_label=case"
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
-    assert len(str(r.data, 'utf-8').strip().split('\n')) == case_count + 1
+    assert r.headers["Content-Disposition"].endswith("tsv")
+    assert len(str(r.data, "utf-8").strip().split("\n")) == case_count + 1
 
 
 def test_export_all_node_types_json(client, pg_driver, cgci_blgsp, submitter):
@@ -733,15 +729,13 @@ def test_export_all_node_types_json(client, pg_driver, cgci_blgsp, submitter):
         case = pg_driver.nodes(md.Case).first()
         new_case = md.Case(str(uuid.uuid4()))
         new_case.props = case.props
-        new_case.submitter_id = 'case-2'
+        new_case.submitter_id = "case-2"
         s.add(new_case)
         case_count = pg_driver.nodes(md.Case).count()
-    path = '/v0/submission/CGCI/BLGSP/export/?node_label=case&format=json'
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?node_label=case&format=json"
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('json')
+    assert r.headers["Content-Disposition"].endswith("json")
     js_data = json.loads(r.data)
     assert len(js_data["data"]) == case_count
 
@@ -750,52 +744,44 @@ def test_submit_export_encoding(client, pg_driver, cgci_blgsp, submitter):
     """Test that we can submit and export non-ascii characters without errors"""
     # submit metadata containing non-ascii characters
     headers = submitter
-    data = json.dumps({
-        "type": "experiment",
-        "submitter_id": "BLGSP-submitter-ü",
-        "projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    data = json.dumps(
+        {
+            "type": "experiment",
+            "submitter_id": "BLGSP-submitter-ü",
+            "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 200, resp.data
 
-    node_id = resp.json['entities'][0]['id']
+    node_id = resp.json["entities"][0]["id"]
 
     # TSV single node export
-    path = '/v0/submission/CGCI/BLGSP/export/?ids={}'.format(node_id)
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?ids={}".format(node_id)
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
-    tsv_output = csv.DictReader(StringIO(r.data.decode('utf-8')), delimiter="\t")
+    assert r.headers["Content-Disposition"].endswith("tsv")
+    tsv_output = csv.DictReader(StringIO(r.data.decode("utf-8")), delimiter="\t")
     row = next(tsv_output)
-    assert row['submitter_id'] == 'BLGSP-submitter-ü'
+    assert row["submitter_id"] == "BLGSP-submitter-ü"
 
     # JSON single node export
-    path += '&format=json'
-    r = client.get(
-        path,
-        headers=submitter)
+    path += "&format=json"
+    r = client.get(path, headers=submitter)
     assert len(r.json) == 1
 
     # TSV multiple node export
-    path = '/v0/submission/CGCI/BLGSP/export/?node_label=experiment'
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?node_label=experiment"
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
-    tsv_output = csv.DictReader(StringIO(r.data.decode('utf-8')), delimiter="\t")
+    assert r.headers["Content-Disposition"].endswith("tsv")
+    tsv_output = csv.DictReader(StringIO(r.data.decode("utf-8")), delimiter="\t")
     row = next(tsv_output)
-    assert row['submitter_id'] == 'BLGSP-submitter-ü'
+    assert row["submitter_id"] == "BLGSP-submitter-ü"
 
     # JSON multiple node export
-    path += '&format=json'
-    r = client.get(
-        path,
-        headers=submitter)
+    path += "&format=json"
+    r = client.get(path, headers=submitter)
     assert len(r.json) == 1
 
 
@@ -807,13 +793,12 @@ def test_duplicate_submission(app, pg_driver, cgci_blgsp, submitter):
     data = {
         "type": "experiment",
         "submitter_id": "BLGSP-71-06-00019",
-        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
     }
 
     # convert to TSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/experiment_tmp.tsv"
+        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
@@ -824,22 +809,25 @@ def test_duplicate_submission(app, pg_driver, cgci_blgsp, submitter):
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
-    program, project = BLGSP_PATH.split('/')[3:5]
+    program, project = BLGSP_PATH.split("/")[3:5]
     tsv_data = TSVToJSONConverter().convert(data)[0]
-    doc_args = [None, 'tsv', data, tsv_data]
-    utx1, utx2 = [UploadTransaction(
-        program=program,
-        project=project,
-        role=ROLES['UPDATE'],
-        logger=app.logger,
-        flask_config=app.config,
-        index_client=app.index_client,
-        external_proxies=get_external_proxies(),
-        db_driver=pg_driver,
-    ) for _ in range(2)]
+    doc_args = [None, "tsv", data, tsv_data]
+    utx1, utx2 = [
+        UploadTransaction(
+            program=program,
+            project=project,
+            role=ROLES["UPDATE"],
+            logger=app.logger,
+            flask_config=app.config,
+            index_client=app.index_client,
+            external_proxies=get_external_proxies(),
+            db_driver=pg_driver,
+        )
+        for _ in range(2)
+    ]
 
     response = ""
     with pg_driver.session_scope(can_inherit=False) as s1:
@@ -866,9 +854,12 @@ def test_duplicate_submission(app, pg_driver, cgci_blgsp, submitter):
                 utx1.integrity_check()
                 response = utx1.json
 
-    assert response["entity_error_count"]==1
-    assert response["code"]==400
-    assert response['entities'][0]['errors'][0]['message'] == "experiment with {'project_id': 'CGCI-BLGSP', 'submitter_id': 'BLGSP-71-06-00019'} already exists in the DB"
+    assert response["entity_error_count"] == 1
+    assert response["code"] == 400
+    assert (
+        response["entities"][0]["errors"][0]["message"]
+        == "experiment with {'project_id': 'CGCI-BLGSP', 'submitter_id': 'BLGSP-71-06-00019'} already exists in the DB"
+    )
 
     with pg_driver.session_scope():
         assert pg_driver.nodes(md.Experiment).count() == 1

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -9,7 +9,7 @@ import csv
 import json
 import os
 import uuid
-from StringIO import StringIO
+from io import StringIO
 
 import boto
 import pytest
@@ -112,7 +112,7 @@ def put_tcga_brca(client, submitter):
 def test_program_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci(client, auth=admin)
     assert resp.status_code == 200, resp.data
-    print resp.data
+    print(resp.data)
     resp = client.get('/v0/submission/')
     assert resp.json['links'] == ['/v0/submission/CGCI'], resp.json
 
@@ -212,7 +212,7 @@ def test_put_valid_entity_missing_target(client, pg_driver, cgci_blgsp, submitte
         data=json.dumps(sample)
     )
 
-    print r.data
+    print(r.data)
     assert r.status_code == 400, r.data
     assert r.status_code == r.json['code']
     assert r.json['entities'][0]['errors'][0]['keys'] == ['cases'], r.json['entities'][0]['errors']
@@ -256,7 +256,7 @@ def test_put_valid_entity_invalid_type(client, pg_driver, cgci_blgsp, submitter)
             }
         ]))
 
-    print r.json
+    print(r.json)
     assert r.status_code == 400, r.data
     assert r.status_code == r.json['code']
     assert (r.json['entities'][2]['errors'][0]['keys']
@@ -301,13 +301,13 @@ def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter
     with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
         case_sid = json.loads(f.read())['submitter_id']
     resp = post_example_entities_together(client, submitter)
-    print resp.data
+    print(resp.data)
     assert resp.status_code == 201, resp.data
 
 
 def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
     resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary')
-    print resp.data
+    print(resp.data)
     assert "/v0/submission/CGCI/BLGSP/_dictionary/slide" \
            in json.loads(resp.data)['links']
     assert "/v0/submission/CGCI/BLGSP/_dictionary/case" \
@@ -318,7 +318,7 @@ def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
 
 def test_top_level_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
     resp = client.get('/v0/submission/_dictionary')
-    print resp.data
+    print(resp.data)
     assert "/v0/submission/_dictionary/slide" \
            in json.loads(resp.data)['links']
     assert "/v0/submission/_dictionary/case" \
@@ -395,7 +395,7 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
     with pg_driver.session_scope():
         case = pg_driver.nodes(md.Case).first()
         ct = case.created_datetime
-        print case.props
+        print(case.props)
         assert ct is not None, case.props
 
 
@@ -498,7 +498,7 @@ def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
     "key1": "valid value",
     "key2": not a string,
 }""")
-    print resp.data
+    print(resp.data)
     assert resp.status_code == 400
     assert 'Expecting value' in resp.json['message']
 

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -724,7 +724,7 @@ def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
         headers=submitter)
     assert r.status_code == 200, r.data
     assert r.headers['Content-Disposition'].endswith('tsv')
-    assert len(r.data.strip().split('\n')) == case_count + 1
+    assert len(str(r.data, 'utf-8').strip().split('\n')) == case_count + 1
 
 
 def test_export_all_node_types_json(client, pg_driver, cgci_blgsp, submitter):
@@ -769,7 +769,7 @@ def test_submit_export_encoding(client, pg_driver, cgci_blgsp, submitter):
         headers=submitter)
     assert r.status_code == 200, r.data
     assert r.headers['Content-Disposition'].endswith('tsv')
-    tsv_output = csv.DictReader(StringIO(r.data), delimiter="\t")
+    tsv_output = csv.DictReader(StringIO(r.data.decode('utf-8')), delimiter="\t")
     row = next(tsv_output)
     assert row['submitter_id'] == 'BLGSP-submitter-ü'
 
@@ -787,7 +787,7 @@ def test_submit_export_encoding(client, pg_driver, cgci_blgsp, submitter):
         headers=submitter)
     assert r.status_code == 200, r.data
     assert r.headers['Content-Disposition'].endswith('tsv')
-    tsv_output = csv.DictReader(StringIO(r.data), delimiter="\t")
+    tsv_output = csv.DictReader(StringIO(r.data.decode('utf-8')), delimiter="\t")
     row = next(tsv_output)
     assert row['submitter_id'] == 'BLGSP-submitter-ü'
 

--- a/tests/integration/datadict/submission/test_upload.py
+++ b/tests/integration/datadict/submission/test_upload.py
@@ -61,7 +61,9 @@ def submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp):
     assert resp.status_code == 200, resp.data
 
 
-def submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp, data=None, format="json"):
+def submit_metadata_file(
+    client, pg_driver, admin, submitter, cgci_blgsp, data=None, format="json"
+):
     data = data or DEFAULT_METADATA_FILE
     headers = submitter
     put_cgci_blgsp(client, admin)
@@ -69,7 +71,7 @@ def submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp, data=N
         headers["Content-Type"] = "text/tsv"
     elif format == "csv":
         headers["Content-Type"] = "text/csv"
-    else: # json
+    else:  # json
         data = json.dumps(data)
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     return resp
@@ -150,7 +152,7 @@ def test_tsv_submission_handle_array_type(client):
     doc = None
     with open(file_path, "r") as f:
         doc = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert doc
 
     from sheepdog.utils.transforms import TSVToJSONConverter
@@ -923,8 +925,7 @@ def test_submit_valid_tsv_data_file(
 
     # convert to TSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/file_tmp.tsv"
+        os.path.dirname(os.path.realpath(__file__)), "data/file_tmp.tsv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(file.keys()), delimiter="\t")
@@ -935,7 +936,7 @@ def test_submit_valid_tsv_data_file(
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     resp = submit_metadata_file(
@@ -995,8 +996,7 @@ def test_submit_valid_csv_data_file(
 
     # convert to CSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/file_tmp.csv"
+        os.path.dirname(os.path.realpath(__file__)), "data/file_tmp.csv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(file.keys()), delimiter=",")
@@ -1007,7 +1007,7 @@ def test_submit_valid_csv_data_file(
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     resp = submit_metadata_file(
@@ -1132,8 +1132,7 @@ def test_can_submit_data_file_with_asterisk_tsv(
 
     # convert to TSV (save to file)
     file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data/file_tmp.tsv"
+        os.path.dirname(os.path.realpath(__file__)), "data/file_tmp.tsv"
     )
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(file.keys()), delimiter="\t")
@@ -1144,7 +1143,7 @@ def test_can_submit_data_file_with_asterisk_tsv(
     data = None
     with open(file_path, "r") as f:
         data = f.read()
-    os.remove(file_path) # clean up (delete file)
+    os.remove(file_path)  # clean up (delete file)
     assert data
 
     resp = submit_metadata_file(

--- a/tests/integration/datadict/submission/test_upload.py
+++ b/tests/integration/datadict/submission/test_upload.py
@@ -8,11 +8,11 @@ import copy
 import os
 import random
 
-from test_endpoints import put_cgci_blgsp
+from .test_endpoints import put_cgci_blgsp
 
-from utils import assert_positive_response
-from utils import assert_negative_response
-from utils import assert_single_entity_from_response
+from .utils import assert_positive_response
+from .utils import assert_negative_response
+from .utils import assert_single_entity_from_response
 
 # Python 2 and 3 compatible
 try:

--- a/tests/integration/datadictwithobjid/api.py
+++ b/tests/integration/datadictwithobjid/api.py
@@ -136,19 +136,19 @@ ALIAS_HOST = "alias.sq3"
 
 INDEX_TABLES = {
     "index_record": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"rev", u"VARCHAR", 0, None, 0),
-        (2, u"form", u"VARCHAR", 0, None, 0),
-        (3, u"size", u"INTEGER", 0, None, 0),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "rev", "VARCHAR", 0, None, 0),
+        (2, "form", "VARCHAR", 0, None, 0),
+        (3, "size", "INTEGER", 0, None, 0),
     ],
     "index_record_hash": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"hash_type", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
-        (2, u"hash_value", u"VARCHAR", 0, None, 0),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "hash_type", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (2, "hash_value", "VARCHAR", 0, None, 0),
     ],
     "index_record_url": [
-        (0, u"did", u"VARCHAR", 1, None, 1),
-        (1, u"url", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (0, "did", "VARCHAR", 1, None, 1),
+        (1, "url", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
     ],
 }
 
@@ -156,21 +156,21 @@ INDEX_TABLES = {
 # pulled from indexd/tests/test_setup.py
 ALIAS_TABLES = {
     "alias_record": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"rev", u"VARCHAR", 0, None, 0),
-        (2, u"size", u"INTEGER", 0, None, 0),
-        (3, u"release", u"VARCHAR", 0, None, 0),
-        (4, u"metastring", u"VARCHAR", 0, None, 0),
-        (5, u"keeper_authority", u"VARCHAR", 0, None, 0),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "rev", "VARCHAR", 0, None, 0),
+        (2, "size", "INTEGER", 0, None, 0),
+        (3, "release", "VARCHAR", 0, None, 0),
+        (4, "metastring", "VARCHAR", 0, None, 0),
+        (5, "keeper_authority", "VARCHAR", 0, None, 0),
     ],
     "alias_record_hash": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"hash_type", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
-        (2, u"hash_value", u"VARCHAR", 0, None, 0),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "hash_type", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (2, "hash_value", "VARCHAR", 0, None, 0),
     ],
     "alias_record_host_authority": [
-        (0, u"name", u"VARCHAR", 1, None, 1),
-        (1, u"host", u"VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
+        (0, "name", "VARCHAR", 1, None, 1),
+        (1, "host", "VARCHAR", 1, None, 1 if OLD_SQLITE else 2),
     ],
 }
 

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -24,6 +24,7 @@ from tests.integration.datadictwithobjid.api import app as _app, app_init, index
 from tests.integration.datadictwithobjid.submission.test_endpoints import put_cgci_blgsp
 from tests import utils
 
+
 def get_parent(path):
     print(path)
     return path[0 : path.rfind("/")]

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -23,6 +23,7 @@ from sheepdog.test_settings import INDEX_CLIENT
 from tests.integration.datadictwithobjid.api import app as _app, app_init, indexd_init
 from tests.integration.datadictwithobjid.submission.test_endpoints import put_cgci_blgsp
 from tests import utils
+import imp
 
 
 def get_parent(path):
@@ -81,7 +82,7 @@ def app(tmpdir, request):
     dictionary_setup(_app)
     # this is to make sure sqlite is initialized
     # for every unit test
-    reload(default_settings)
+    imp.reload(default_settings)
 
     # fresh files before running
     for filename in ["auth.sq3", "index.sq3", "alias.sq3"]:

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -23,8 +23,6 @@ from sheepdog.test_settings import INDEX_CLIENT
 from tests.integration.datadictwithobjid.api import app as _app, app_init, indexd_init
 from tests.integration.datadictwithobjid.submission.test_endpoints import put_cgci_blgsp
 from tests import utils
-import imp
-
 
 def get_parent(path):
     print(path)
@@ -82,7 +80,7 @@ def app(tmpdir, request):
     dictionary_setup(_app)
     # this is to make sure sqlite is initialized
     # for every unit test
-    imp.reload(default_settings)
+    reload(default_settings)
 
     # fresh files before running
     for filename in ["auth.sq3", "index.sq3", "alias.sq3"]:

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -1,6 +1,6 @@
-from imp import reload
 import os
 import json
+import importlib
 from multiprocessing import Process
 
 from indexd import default_settings, get_app as get_indexd_app
@@ -81,7 +81,7 @@ def app(tmpdir, request):
     dictionary_setup(_app)
     # this is to make sure sqlite is initialized
     # for every unit test
-    reload(default_settings)
+    importlib.reload(default_settings)
 
     # fresh files before running
     for filename in ["auth.sq3", "index.sq3", "alias.sq3"]:

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -168,7 +168,9 @@ def cgci_blgsp(client, admin):
 
 @pytest.fixture()
 def index_client():
-    return IndexClient(INDEX_CLIENT["host"], INDEX_CLIENT["version"], INDEX_CLIENT["auth"])
+    return IndexClient(
+        INDEX_CLIENT["host"], INDEX_CLIENT["version"], INDEX_CLIENT["auth"]
+    )
 
 
 def dictionary_setup(_app):

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -113,7 +113,7 @@ def put_tcga_brca(client, submitter):
 def test_program_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci(client, auth=admin)
     assert resp.status_code == 200, resp.data
-    print resp.data
+    print(resp.data)
     resp = client.get('/v0/submission/')
     assert resp.json['links'] == ['/v0/submission/CGCI'], resp.json
 
@@ -233,7 +233,7 @@ def test_put_valid_entity_missing_target(client, pg_driver, cgci_blgsp, submitte
         data=json.dumps(sample)
     )
 
-    print r.data
+    print(r.data)
     assert r.status_code == 400, r.data
     assert r.status_code == r.json['code']
     assert r.json['entities'][0]['errors'][0]['keys'] == ['cases'], r.json['entities'][0]['errors']
@@ -277,7 +277,7 @@ def test_put_valid_entity_invalid_type(client, pg_driver, cgci_blgsp, submitter)
             }
         ]))
 
-    print r.json
+    print(r.json)
     assert r.status_code == 400, r.data
     assert r.status_code == r.json['code']
     assert (r.json['entities'][2]['errors'][0]['keys']
@@ -322,13 +322,13 @@ def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter
     with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
         case_sid = json.loads(f.read())['submitter_id']
     resp = post_example_entities_together(client, submitter)
-    print resp.data
+    print(resp.data)
     assert resp.status_code == 201, resp.data
 
 
 def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
     resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary')
-    print resp.data
+    print(resp.data)
     assert "/v0/submission/CGCI/BLGSP/_dictionary/slide" \
            in json.loads(resp.data)['links']
     assert "/v0/submission/CGCI/BLGSP/_dictionary/case" \
@@ -339,7 +339,7 @@ def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
 
 def test_top_level_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
     resp = client.get('/v0/submission/_dictionary')
-    print resp.data
+    print(resp.data)
     assert "/v0/submission/_dictionary/slide" \
            in json.loads(resp.data)['links']
     assert "/v0/submission/_dictionary/case" \
@@ -416,7 +416,7 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
     with pg_driver.session_scope():
         case = pg_driver.nodes(md.Case).first()
         ct = case.created_datetime
-        print case.props
+        print(case.props)
         assert ct is not None, case.props
 
 
@@ -519,7 +519,7 @@ def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
     "key1": "valid value",
     "key2": not a string,
 }""")
-    print resp.data
+    print(resp.data)
     assert resp.status_code == 400
     assert 'Expecting value' in resp.json['message']
 
@@ -594,7 +594,7 @@ def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter,
         path,
         headers=submitter)
 
-    print r.json
+    print(r.json)
     data = r.json
     assert data and len(data) == 1
     object_id = data[0]['object_id']

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -18,10 +18,10 @@ from sheepdog.transactions.upload import UploadTransaction
 from tests.integration.datadict.submission.utils import data_fnames
 
 
-BLGSP_PATH = '/v0/submission/CGCI/BLGSP/'
-BRCA_PATH = '/v0/submission/TCGA/BRCA/'
+BLGSP_PATH = "/v0/submission/CGCI/BLGSP/"
+BRCA_PATH = "/v0/submission/TCGA/BRCA/"
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
 
 @contextlib.contextmanager
@@ -30,7 +30,7 @@ def s3_conn():
     mock.start(reset=False)
     conn = boto.connect_s3()
     yield conn
-    bucket = conn.get_bucket('test_submission')
+    bucket = conn.get_bucket("test_submission")
     for part in bucket.list_multipart_uploads():
         part.cancel_upload()
     mock.stop()
@@ -41,7 +41,7 @@ def mock_request(f):
         mock = mock_s3()
         mock.start(reset=False)
         conn = boto.connect_s3()
-        conn.create_bucket('test_submission')
+        conn.create_bucket("test_submission")
 
         result = f(*args, **kwargs)
         mock.stop()
@@ -51,37 +51,38 @@ def mock_request(f):
 
 
 def put_cgci(client, auth=None):
-    path = '/v0/submission'
+    path = "/v0/submission"
     headers = auth
-    data = json.dumps({
-        'name': 'CGCI', 'type': 'program',
-        'dbgap_accession_number': 'phs000235'
-    })
+    data = json.dumps(
+        {"name": "CGCI", "type": "program", "dbgap_accession_number": "phs000235"}
+    )
     r = client.put(path, headers=headers, data=data)
     return r
 
+
 def put_cgci2(client, auth=None):
-    path = '/v0/submission'
+    path = "/v0/submission"
     headers = auth
-    data = json.dumps({
-        'name': 'CGCI2', 'type': 'program',
-        'dbgap_accession_number': 'phs0002352'
-    })
+    data = json.dumps(
+        {"name": "CGCI2", "type": "program", "dbgap_accession_number": "phs0002352"}
+    )
     r = client.put(path, headers=headers, data=data)
     return r
 
 
 def put_cgci_blgsp(client, auth=None):
     put_cgci(client, auth=auth)
-    path = '/v0/submission/CGCI/'
+    path = "/v0/submission/CGCI/"
     headers = auth
-    data = json.dumps({
-        "type": "project",
-        "code": "BLGSP",
-        "dbgap_accession_number": 'phs000527',
-        "name": "Burkitt Lymphoma Genome Sequencing Project",
-        "state": "open"
-    })
+    data = json.dumps(
+        {
+            "type": "project",
+            "code": "BLGSP",
+            "dbgap_accession_number": "phs000527",
+            "name": "Burkitt Lymphoma Genome Sequencing Project",
+            "state": "open",
+        }
+    )
     r = client.put(path, headers=headers, data=data)
     assert r.status_code == 200, r.data
     del g.user
@@ -90,21 +91,22 @@ def put_cgci_blgsp(client, auth=None):
 
 def put_tcga_brca(client, submitter):
     headers = submitter
-    data = json.dumps({
-        'name': 'TCGA', 'type': 'program',
-        'dbgap_accession_number': 'phs000178'
-    })
-    r = client.put('/v0/submission/', headers=headers, data=data)
+    data = json.dumps(
+        {"name": "TCGA", "type": "program", "dbgap_accession_number": "phs000178"}
+    )
+    r = client.put("/v0/submission/", headers=headers, data=data)
     assert r.status_code == 200, r.data
     headers = submitter
-    data = json.dumps({
-        "type": "project",
-        "code": "BRCA",
-        "name": "TEST",
-        "dbgap_accession_number": "phs000178",
-        "state": "open"
-    })
-    r = client.put('/v0/submission/TCGA/', headers=headers, data=data)
+    data = json.dumps(
+        {
+            "type": "project",
+            "code": "BRCA",
+            "name": "TEST",
+            "dbgap_accession_number": "phs000178",
+            "state": "open",
+        }
+    )
+    r = client.put("/v0/submission/TCGA/", headers=headers, data=data)
     assert r.status_code == 200, r.data
     del g.user
     return r
@@ -114,21 +116,22 @@ def test_program_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci(client, auth=admin)
     assert resp.status_code == 200, resp.data
     print(resp.data)
-    resp = client.get('/v0/submission/')
-    assert resp.json['links'] == ['/v0/submission/CGCI'], resp.json
+    resp = client.get("/v0/submission/")
+    assert resp.json["links"] == ["/v0/submission/CGCI"], resp.json
 
 
 def test_program_creation_without_admin_token(client, pg_driver, submitter):
-    path = '/v0/submission/'
+    path = "/v0/submission/"
     headers = submitter
-    data = json.dumps({'name': 'CGCI', 'type': 'program'})
+    data = json.dumps({"name": "CGCI", "type": "program"})
     resp = client.put(path, headers=headers, data=data)
     assert resp.status_code == 403
 
 
 def test_program_creation_endpoint_for_program_not_supported(
-        client, pg_driver, submitter):
-    path = '/v0/submission/abc/'
+    client, pg_driver, submitter
+):
+    path = "/v0/submission/abc/"
     resp = client.post(path, headers=submitter)
     assert resp.status_code == 404
 
@@ -137,110 +140,121 @@ def test_project_creation_endpoint(client, pg_driver, admin):
     resp = put_cgci_blgsp(client, auth=admin)
     assert resp.status_code == 200
 
-    resp = client.get('/v0/submission/CGCI/')
+    resp = client.get("/v0/submission/CGCI/")
     with pg_driver.session_scope():
         assert pg_driver.nodes(md.Project).count() == 1
-        n_cgci = (
-            pg_driver.nodes(md.Project)
-            .path('programs')
-            .props(name='CGCI')
-            .count()
-        )
+        n_cgci = pg_driver.nodes(md.Project).path("programs").props(name="CGCI").count()
         assert n_cgci == 1
-    assert resp.json['links'] == ['/v0/submission/CGCI/BLGSP'], resp.json
+    assert resp.json["links"] == ["/v0/submission/CGCI/BLGSP"], resp.json
 
 
 def test_project_creation_without_admin_token(client, pg_driver, submitter, admin):
     put_cgci(client, admin)
-    path = '/v0/submission/CGCI/'
+    path = "/v0/submission/CGCI/"
     resp = client.put(
-        path, headers=submitter, data=json.dumps({
-            "type": "project",
-            "code": "BLGSP",
-            "dbgap_accession_number": "phs000527",
-            "name": "Burkitt Lymphoma Genome Sequencing Project",
-            "state": "open"}))
+        path,
+        headers=submitter,
+        data=json.dumps(
+            {
+                "type": "project",
+                "code": "BLGSP",
+                "dbgap_accession_number": "phs000527",
+                "name": "Burkitt Lymphoma Genome Sequencing Project",
+                "state": "open",
+            }
+        ),
+    )
     assert resp.status_code == 403
 
 
-def test_project_creation_invalid_due_to_registed_project_name(client, pg_driver, admin):
+def test_project_creation_invalid_due_to_registed_project_name(
+    client, pg_driver, admin
+):
     resp = put_cgci_blgsp(client, auth=admin)
     assert resp.status_code == 200
     resp = put_cgci2(client, auth=admin)
     assert resp.status_code == 200
 
-    path = '/v0/submission/CGCI2/'
+    path = "/v0/submission/CGCI2/"
     resp = client.put(
-        path, headers=admin, data=json.dumps({
-            "type": "project",
-            "code": "BLGSP",
-            "dbgap_accession_number": "phs000527",
-            "name": "Burkitt Lymphoma Genome Sequencing Project",
-            "state": "open"}))
+        path,
+        headers=admin,
+        data=json.dumps(
+            {
+                "type": "project",
+                "code": "BLGSP",
+                "dbgap_accession_number": "phs000527",
+                "name": "Burkitt Lymphoma Genome Sequencing Project",
+                "state": "open",
+            }
+        ),
+    )
     assert resp.status_code == 400
 
 
 def test_put_entity_creation_valid(client, pg_driver, cgci_blgsp, submitter):
     headers = submitter
-    data = json.dumps({
-        "type": "experiment",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    data = json.dumps(
+        {
+            "type": "experiment",
+            "submitter_id": "BLGSP-71-06-00019",
+            "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 200, resp.data
 
 
 def test_unauthenticated_post(client, pg_driver, cgci_blgsp, submitter):
     # garbage token
-    headers = {'Authorization': 'test'}
-    data = json.dumps({
-        "type": "case",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects": {
-            "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+    headers = {"Authorization": "test"}
+    data = json.dumps(
+        {
+            "type": "case",
+            "submitter_id": "BLGSP-71-06-00019",
+            "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
         }
-    })
+    )
     resp = client.post(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 401
 
 
-def test_unauthorized_post(client, pg_driver, cgci_blgsp, submitter, mock_arborist_requests):
+def test_unauthorized_post(
+    client, pg_driver, cgci_blgsp, submitter, mock_arborist_requests
+):
     headers = submitter
     mock_arborist_requests(authorized=False)
     resp = client.post(
-        BLGSP_PATH, headers=headers, data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
+        BLGSP_PATH,
+        headers=headers,
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
             }
-        })
+        ),
     )
     assert resp.status_code == 403
 
 
 def test_put_valid_entity_missing_target(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, 'sample.json'), 'r') as f:
+    with open(os.path.join(DATA_DIR, "sample.json"), "r") as f:
         sample = json.loads(f.read())
-        sample['cases'] = {"submitter_id": "missing-case"}
+        sample["cases"] = {"submitter_id": "missing-case"}
 
-    r = client.put(
-        BLGSP_PATH,
-        headers=submitter,
-        data=json.dumps(sample)
-    )
+    r = client.put(BLGSP_PATH, headers=submitter, data=json.dumps(sample))
 
     print(r.data)
     assert r.status_code == 400, r.data
-    assert r.status_code == r.json['code']
-    assert r.json['entities'][0]['errors'][0]['keys'] == ['cases'], r.json['entities'][0]['errors']
-    assert r.json['entities'][0]['errors'][0]['type'] == 'INVALID_LINK'
+    assert r.status_code == r.json["code"]
+    assert r.json["entities"][0]["errors"][0]["keys"] == ["cases"], r.json["entities"][
+        0
+    ]["errors"]
+    assert r.json["entities"][0]["errors"][0]["type"] == "INVALID_LINK"
     assert (
         "[{'project_id': 'CGCI-BLGSP', 'submitter_id': 'missing-case'}]"
-        in r.json['entities'][0]['errors'][0]['message']
+        in r.json["entities"][0]["errors"][0]["message"]
     )
 
 
@@ -248,53 +262,46 @@ def test_put_valid_entity_invalid_type(client, pg_driver, cgci_blgsp, submitter)
     r = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps([
-            {
-                "type": "experiment",
-                "submitter_id": "BLGSP-71-06-00019",
-                "projects": {
-                    "code": "BLGSP"
-                }
-            },
-            {
-                "type": "case",
-                "submitter_id": "BLGSP-71-case-01",
-                "experiments": {
-                    "submitter_id": 'BLGSP-71-06-00019'
-                }
-            },
-            {
-                'type': "demographic",
-                'ethnicity': 'not reported',
-                'gender': 'male',
-                'race': 'asian',
-                'submitter_id': 'demographic1',
-                'year_of_birth': '1900',
-                'year_of_death': 2000,
-                'cases': {
-                    'submitter_id': 'BLGSP-71-case-01'
-                }
-            }
-        ]))
+        data=json.dumps(
+            [
+                {
+                    "type": "experiment",
+                    "submitter_id": "BLGSP-71-06-00019",
+                    "projects": {"code": "BLGSP"},
+                },
+                {
+                    "type": "case",
+                    "submitter_id": "BLGSP-71-case-01",
+                    "experiments": {"submitter_id": "BLGSP-71-06-00019"},
+                },
+                {
+                    "type": "demographic",
+                    "ethnicity": "not reported",
+                    "gender": "male",
+                    "race": "asian",
+                    "submitter_id": "demographic1",
+                    "year_of_birth": "1900",
+                    "year_of_death": 2000,
+                    "cases": {"submitter_id": "BLGSP-71-case-01"},
+                },
+            ]
+        ),
+    )
 
     print(r.json)
     assert r.status_code == 400, r.data
-    assert r.status_code == r.json['code']
-    assert (r.json['entities'][2]['errors'][0]['keys']
-            == ['year_of_birth']), r.data
-    assert (r.json['entities'][2]['errors'][0]['type']
-            == 'INVALID_VALUE'), r.data
+    assert r.status_code == r.json["code"]
+    assert r.json["entities"][2]["errors"][0]["keys"] == ["year_of_birth"], r.data
+    assert r.json["entities"][2]["errors"][0]["type"] == "INVALID_VALUE", r.data
 
 
 def test_post_example_entities(client, pg_driver, cgci_blgsp, submitter):
     path = BLGSP_PATH
-    with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
-        case_sid = json.loads(f.read())['submitter_id']
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
     for fname in data_fnames:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
-            resp = client.post(
-                path, headers=submitter, data=f.read()
-            )
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
+            resp = client.post(path, headers=submitter, data=f.read())
             assert resp.status_code == 201, resp.data
 
 
@@ -304,7 +311,7 @@ def post_example_entities_together(client, submitter, data_fnames2=None):
     path = BLGSP_PATH
     data = []
     for fname in data_fnames2:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
             data.append(json.loads(f.read()))
     return client.post(path, headers=submitter, data=json.dumps(data))
 
@@ -313,71 +320,74 @@ def put_example_entities_together(client, headers):
     path = BLGSP_PATH
     data = []
     for fname in data_fnames:
-        with open(os.path.join(DATA_DIR, fname), 'r') as f:
+        with open(os.path.join(DATA_DIR, fname), "r") as f:
             data.append(json.loads(f.read()))
     return client.put(path, headers=headers, data=json.dumps(data))
 
 
 def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, 'case.json'), 'r') as f:
-        case_sid = json.loads(f.read())['submitter_id']
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
     resp = post_example_entities_together(client, submitter)
     print(resp.data)
     assert resp.status_code == 201, resp.data
 
 
 def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary')
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary")
     print(resp.data)
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/slide" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/case" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/CGCI/BLGSP/_dictionary/aliquot" \
-           in json.loads(resp.data)['links']
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/slide" in json.loads(resp.data)["links"]
+    )
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/case" in json.loads(resp.data)["links"]
+    )
+    assert (
+        "/v0/submission/CGCI/BLGSP/_dictionary/aliquot"
+        in json.loads(resp.data)["links"]
+    )
 
 
 def test_top_level_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/_dictionary')
+    resp = client.get("/v0/submission/_dictionary")
     print(resp.data)
-    assert "/v0/submission/_dictionary/slide" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/_dictionary/case" \
-           in json.loads(resp.data)['links']
-    assert "/v0/submission/_dictionary/aliquot" \
-           in json.loads(resp.data)['links']
+    assert "/v0/submission/_dictionary/slide" in json.loads(resp.data)["links"]
+    assert "/v0/submission/_dictionary/case" in json.loads(resp.data)["links"]
+    assert "/v0/submission/_dictionary/aliquot" in json.loads(resp.data)["links"]
 
 
 def test_dictionary_get_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary/aliquot')
-    assert json.loads(resp.data)['id'] == 'aliquot'
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary/aliquot")
+    assert json.loads(resp.data)["id"] == "aliquot"
 
 
 def test_top_level_dictionary_get_entries(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/_dictionary/aliquot')
-    assert json.loads(resp.data)['id'] == 'aliquot'
+    resp = client.get("/v0/submission/_dictionary/aliquot")
+    assert json.loads(resp.data)["id"] == "aliquot"
 
 
 def test_dictionary_get_definitions(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.get('/v0/submission/CGCI/BLGSP/_dictionary/_definitions')
-    assert 'UUID' in resp.json
+    resp = client.get("/v0/submission/CGCI/BLGSP/_dictionary/_definitions")
+    assert "UUID" in resp.json
 
 
 def test_put_dry_run(client, pg_driver, cgci_blgsp, submitter):
-    path = '/v0/submission/CGCI/BLGSP/_dry_run/'
+    path = "/v0/submission/CGCI/BLGSP/_dry_run/"
     resp = client.put(
         path,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     assert resp.status_code == 200, resp.data
     resp_json = json.loads(resp.data)
-    assert resp_json['entity_error_count'] == 0
-    assert resp_json['created_entity_count'] == 1
+    assert resp_json["entity_error_count"] == 0
+    assert resp_json["created_entity_count"] == 1
     with pg_driver.session_scope():
         assert not pg_driver.nodes(md.Experiment).first()
 
@@ -387,28 +397,31 @@ def test_incorrect_project_error(client, pg_driver, cgci_blgsp, submitter, admin
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     resp = client.put(
         BRCA_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     resp_json = json.loads(resp.data)
     assert resp.status_code == 400
-    assert resp_json['code'] == 400
-    assert resp_json['entity_error_count'] == 1
-    assert resp_json['created_entity_count'] == 0
-    assert (resp_json['entities'][0]['errors'][0]['type']
-            == 'INVALID_PERMISSIONS')
+    assert resp_json["code"] == 400
+    assert resp_json["entity_error_count"] == 1
+    assert resp_json["created_entity_count"] == 0
+    assert resp_json["entities"][0]["errors"][0]["type"] == "INVALID_PERMISSIONS"
 
 
 def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
@@ -420,7 +433,9 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
         assert ct is not None, case.props
 
 
-def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submitter, admin):
+def test_disallow_cross_project_references(
+    client, pg_driver, cgci_blgsp, submitter, admin
+):
     put_tcga_brca(client, admin)
     data = {
         "progression_or_recurrence": "unknown",
@@ -437,18 +452,13 @@ def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submit
         "age_at_diagnosis": 47,
         "vital_status": "dead",
         "morphology": "8255/3",
-        "cases": {
-            "submitter_id": "BLGSP-71-06-00019"
-        },
+        "cases": {"submitter_id": "BLGSP-71-06-00019"},
         "type": "diagnosis",
         "prior_malignancy": "no",
         "days_to_recurrence": -1,
-        "days_to_last_known_disease_status": -1
+        "days_to_last_known_disease_status": -1,
     }
-    resp = client.put(
-        BRCA_PATH,
-        headers=submitter,
-        data=json.dumps(data))
+    resp = client.put(BRCA_PATH, headers=submitter, data=json.dumps(data))
     assert resp.status_code == 400, resp.data
 
 
@@ -456,15 +466,17 @@ def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
     assert resp.status_code == 200, resp.data
-    did = resp.json['entities'][0]['id']
-    path = BLGSP_PATH + 'entities/' + did
+    did = resp.json["entities"][0]["id"]
+    path = BLGSP_PATH + "entities/" + did
     resp = client.delete(path, headers=submitter)
     assert resp.status_code == 200, resp.data
 
@@ -476,12 +488,12 @@ def test_catch_internal_errors(monkeypatch, client, pg_driver, cgci_blgsp, submi
     """
 
     def just_raise_exception(self):
-        raise Exception('test')
+        raise Exception("test")
 
-    monkeypatch.setattr(UploadTransaction, 'pre_validate', just_raise_exception)
+    monkeypatch.setattr(UploadTransaction, "pre_validate", just_raise_exception)
     try:
         r = put_example_entities_together(client, submitter)
-        assert len(r.json['transactional_errors']) == 1, r.data
+        assert len(r.json["transactional_errors"]) == 1, r.data
     except:
         raise
 
@@ -492,23 +504,21 @@ def test_validator_error_types(client, pg_driver, cgci_blgsp, submitter):
     r = client.put(
         BLGSP_PATH,
         headers=submitter,
-        data=json.dumps({
-            "type": "sample",
-            "cases": {
-                "submitter_id": "BLGSP-71-06-00019"
-            },
-            "is_ffpe": "maybe",
-            "sample_type": "Blood Derived Normal",
-            "submitter_id": "BLGSP-71-06-00019",
-            "longest_dimension": -1.0
-        }))
-    errors = {
-        e['keys'][0]: e['type']
-        for e in r.json['entities'][0]['errors']
-    }
+        data=json.dumps(
+            {
+                "type": "sample",
+                "cases": {"submitter_id": "BLGSP-71-06-00019"},
+                "is_ffpe": "maybe",
+                "sample_type": "Blood Derived Normal",
+                "submitter_id": "BLGSP-71-06-00019",
+                "longest_dimension": -1.0,
+            }
+        ),
+    )
+    errors = {e["keys"][0]: e["type"] for e in r.json["entities"][0]["errors"]}
     assert r.status_code == 400, r.data
-    assert errors['is_ffpe'] == 'INVALID_VALUE'
-    assert errors['longest_dimension'] == 'INVALID_VALUE'
+    assert errors["is_ffpe"] == "INVALID_VALUE"
+    assert errors["longest_dimension"] == "INVALID_VALUE"
 
 
 def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
@@ -518,22 +528,21 @@ def test_invalid_json(client, pg_driver, cgci_blgsp, submitter):
         data="""{
     "key1": "valid value",
     "key2": not a string,
-}""")
+}""",
+    )
     print(resp.data)
     assert resp.status_code == 400
-    assert 'Expecting value' in resp.json['message']
+    assert "Expecting value" in resp.json["message"]
 
 
 def test_get_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
     post_example_entities_together(client, submitter)
     with pg_driver.session_scope():
         case_id = pg_driver.nodes(md.Case).first().node_id
-    path = '/v0/submission/CGCI/BLGSP/entities/{case_id}'.format(case_id=case_id)
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/entities/{case_id}".format(case_id=case_id)
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.json['entities'][0]['properties']['id'] == case_id, r.data
+    assert r.json["entities"][0]["properties"]["id"] == case_id, r.data
 
 
 def test_invalid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter):
@@ -541,31 +550,37 @@ def test_invalid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitte
     Test that submitting an invalid data file doesn't create an index and an
     alias.
     """
+
     def fail_index_test(_):
-        raise AssertionError('IndexClient tried to create index or alias')
+        raise AssertionError("IndexClient tried to create index or alias")
 
     # Since the IndexClient should never be called to register anything if the
     # file is invalid, change the ``create`` and ``create_alias`` methods to
     # raise an error.
     monkeypatch.setattr(
-        UploadTransaction, 'index_client.create', fail_index_test, raising=False
+        UploadTransaction, "index_client.create", fail_index_test, raising=False
     )
     monkeypatch.setattr(
-        UploadTransaction, 'index_client.create_alias', fail_index_test,
-        raising=False
+        UploadTransaction, "index_client.create_alias", fail_index_test, raising=False
     )
     # Attempt to post the invalid entities.
-    test_fnames = (
-        data_fnames
-        + ['read_group.json', 'submitted_unaligned_reads_invalid.json']
-    )
-    resp = post_example_entities_together(
-        client, submitter, data_fnames2=test_fnames
-    )
+    test_fnames = data_fnames + [
+        "read_group.json",
+        "submitted_unaligned_reads_invalid.json",
+    ]
+    resp = post_example_entities_together(client, submitter, data_fnames2=test_fnames)
     print(resp)
 
 
-def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter, index_client, require_index_exists_off):
+def test_valid_file_index(
+    monkeypatch,
+    client,
+    pg_driver,
+    cgci_blgsp,
+    submitter,
+    index_client,
+    require_index_exists_off,
+):
     """
     Test that submitting a valid data file creates an index and an alias.
     """
@@ -574,54 +589,45 @@ def test_valid_file_index(monkeypatch, client, pg_driver, cgci_blgsp, submitter,
     # called.
 
     # Attempt to post the valid entities.
-    test_fnames = (
-        data_fnames
-        + ['read_group.json', 'submitted_unaligned_reads.json']
-    )
-    resp = post_example_entities_together(
-        client, submitter, data_fnames2=test_fnames
-    )
+    test_fnames = data_fnames + ["read_group.json", "submitted_unaligned_reads.json"]
+    resp = post_example_entities_together(client, submitter, data_fnames2=test_fnames)
     assert resp.status_code == 201, resp.data
 
     # this is a node that will have an indexd entry
     sur_entity = None
-    for entity in resp.json['entities']:
-        if entity['type'] == 'submitted_unaligned_reads':
+    for entity in resp.json["entities"]:
+        if entity["type"] == "submitted_unaligned_reads":
             sur_entity = entity
 
-    path = '/v0/submission/CGCI/BLGSP/export/?format=json&ids={nid}'.format(nid=sur_entity['id'])
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?format=json&ids={nid}".format(
+        nid=sur_entity["id"]
+    )
+    r = client.get(path, headers=submitter)
 
     print(r.json)
     data = r.json
     assert data and len(data) == 1
-    object_id = data[0]['object_id']
+    object_id = data[0]["object_id"]
     assert object_id
 
-    assert sur_entity, 'No submitted_unaligned_reads entity created'
-    assert index_client.get(object_id), 'No indexd document created'
+    assert sur_entity, "No submitted_unaligned_reads entity created"
+    assert index_client.get(object_id), "No indexd document created"
 
 
 def test_export_entity_by_id(client, pg_driver, cgci_blgsp, submitter):
     post_example_entities_together(client, submitter)
     with pg_driver.session_scope():
         case_id = pg_driver.nodes(md.Case).first().node_id
-    path = '/v0/submission/CGCI/BLGSP/export/?ids={case_id}'.format(case_id=case_id)
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?ids={case_id}".format(case_id=case_id)
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
+    assert r.headers["Content-Disposition"].endswith("tsv")
 
-    path += '&format=json'
-    r = client.get(
-        path,
-        headers=submitter)
+    path += "&format=json"
+    r = client.get(path, headers=submitter)
     data = r.json
     assert data and len(data) == 1
-    assert data[0]['id'] == case_id
+    assert data[0]["id"] == case_id
 
 
 def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
@@ -630,19 +636,17 @@ def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
         case = pg_driver.nodes(md.Case).first()
         new_case = md.Case(str(uuid.uuid4()))
         new_case.props = case.props
-        new_case.submitter_id = 'case-2'
+        new_case.submitter_id = "case-2"
         s.add(new_case)
         case_count = pg_driver.nodes(md.Case).count()
-    path = '/v0/submission/CGCI/BLGSP/export/?node_label=case'
-    r = client.get(
-        path,
-        headers=submitter)
+    path = "/v0/submission/CGCI/BLGSP/export/?node_label=case"
+    r = client.get(path, headers=submitter)
     assert r.status_code == 200, r.data
-    assert r.headers['Content-Disposition'].endswith('tsv')
-    assert len(str(r.data, 'utf-8').strip().split('\n')) == case_count + 1
+    assert r.headers["Content-Disposition"].endswith("tsv")
+    assert len(str(r.data, "utf-8").strip().split("\n")) == case_count + 1
 
 
-@pytest.mark.parametrize('file_type', ['json', 'tsv'])
+@pytest.mark.parametrize("file_type", ["json", "tsv"])
 def test_export_error(client, cgci_blgsp, submitter, file_type):
     """
     Certain node types and categories cant't be exported through the
@@ -650,12 +654,11 @@ def test_export_error(client, cgci_blgsp, submitter, file_type):
     Test that trying to export using these as the node_label argument fails
     with 400.
     """
-    for node_label in ['root', '_all']:
+    for node_label in ["root", "_all"]:
         path = (
-            '/v0/submission/CGCI/BLGSP/export/'
-            '?file_format={}'
-            '&node_label={}'
-            .format(file_type, node_label)
+            "/v0/submission/CGCI/BLGSP/export/"
+            "?file_format={}"
+            "&node_label={}".format(file_type, node_label)
         )
         response = client.get(path, headers=submitter)
         assert response.status_code == 400
@@ -667,14 +670,18 @@ def test_delete_non_empty_project(client, pg_driver, cgci_blgsp, submitter, admi
     """
     headers = submitter
     resp = client.put(
-        BLGSP_PATH, headers=headers, data=json.dumps({
-            "type": "experiment",
-            "submitter_id": "BLGSP-71-06-00019",
-            "projects": {
-                "id": "daa208a7-f57a-562c-a04a-7a7c77542c98"
-            }}))
+        BLGSP_PATH,
+        headers=headers,
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
 
-    path = '/v0/submission/CGCI/BLGSP'
+    path = "/v0/submission/CGCI/BLGSP"
     resp = client.delete(path, headers=admin)
     assert resp.status_code == 400
 
@@ -683,7 +690,7 @@ def test_delete_project_without_admin_token(client, pg_driver, cgci_blgsp, submi
     """
     Test that returns error when attemping to delete non-empty project
     """
-    path = '/v0/submission/CGCI/BLGSP'
+    path = "/v0/submission/CGCI/BLGSP"
     resp = client.delete(path, headers=submitter)
     assert resp.status_code == 403
 
@@ -692,7 +699,7 @@ def test_delete_non_existed_project(client, pg_driver, cgci_blgsp, submitter, ad
     """
     Test that returns error when attemping to delete a non-existed project
     """
-    path = '/v0/submission/CGCI/NOT_EXIST'
+    path = "/v0/submission/CGCI/NOT_EXIST"
     resp = client.delete(path, headers=admin)
     assert resp.status_code == 404
 
@@ -701,14 +708,11 @@ def test_delete_empty_project(client, pg_driver, cgci_blgsp, submitter, admin):
     """
     Test that successfully deletes an empty project
     """
-    path = '/v0/submission/CGCI/BLGSP'
+    path = "/v0/submission/CGCI/BLGSP"
     resp = client.delete(path, headers=admin)
     assert resp.status_code == 204
     with flask.current_app.db.session_scope():
-        project = (
-            flask.current_app.
-            db.nodes(md.Project).
-            props(code='BLGSP').first())
+        project = flask.current_app.db.nodes(md.Project).props(code="BLGSP").first()
         assert not project
 
 
@@ -716,7 +720,7 @@ def test_delete_empty_non_program(client, pg_driver, cgci_blgsp, admin):
     """
     Test that return error  when attempting to delete a non-empty program
     """
-    path = '/v0/submission/CGCI'
+    path = "/v0/submission/CGCI"
     resp = client.delete(path, headers=admin)
     assert resp.status_code == 400
 
@@ -726,7 +730,7 @@ def test_delete_program_without_admin_token(client, pg_driver, admin, submitter)
     Test that returns error since the client does not have
     privillege to delele the program
     """
-    path = '/v0/submission/CGCI'
+    path = "/v0/submission/CGCI"
     put_cgci(client, admin)
     resp = client.delete(path, headers=submitter)
     assert resp.status_code == 403
@@ -736,15 +740,12 @@ def test_delete_program(client, pg_driver, admin):
     """
     Test that successfully deletes an empty program
     """
-    path = '/v0/submission/CGCI'
+    path = "/v0/submission/CGCI"
     put_cgci(client, admin)
     resp = client.delete(path, headers=admin)
     assert resp.status_code == 204
     with flask.current_app.db.session_scope():
-        program = (
-            flask.current_app.
-            db.nodes(md.Program).
-            props(name='CGCI').first())
+        program = flask.current_app.db.nodes(md.Program).props(name="CGCI").first()
         assert not program
 
 
@@ -754,11 +755,10 @@ def test_update_program_without_admin_token(client, pg_driver, admin, submitter)
     privilege to update the program
     """
     put_cgci(client, admin)
-    data = json.dumps({
-        'name': 'CGCI', 'type': 'program',
-        'dbgap_accession_number': 'phs000235_2'
-    })
-    resp = client.put('/v0/submission', headers=submitter, data=data)
+    data = json.dumps(
+        {"name": "CGCI", "type": "program", "dbgap_accession_number": "phs000235_2"}
+    )
+    resp = client.put("/v0/submission", headers=submitter, data=data)
     assert resp.status_code == 403
 
 
@@ -767,15 +767,11 @@ def test_update_program(client, pg_driver, admin):
     Test that successfully updates a program
     """
     put_cgci(client, admin)
-    data = json.dumps({
-        'name': 'CGCI', 'type': 'program',
-        'dbgap_accession_number': 'phs000235_2'
-    })
-    resp = client.put('/v0/submission', headers=admin, data=data)
+    data = json.dumps(
+        {"name": "CGCI", "type": "program", "dbgap_accession_number": "phs000235_2"}
+    )
+    resp = client.put("/v0/submission", headers=admin, data=data)
     assert resp.status_code == 200
     with flask.current_app.db.session_scope():
-        program = (
-            flask.current_app.
-            db.nodes(md.Program).
-            props(name='CGCI').first())
-        assert program.props['dbgap_accession_number'] == 'phs000235_2'
+        program = flask.current_app.db.nodes(md.Program).props(name="CGCI").first()
+        assert program.props["dbgap_accession_number"] == "phs000235_2"

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -639,7 +639,7 @@ def test_export_all_node_types(client, pg_driver, cgci_blgsp, submitter):
         headers=submitter)
     assert r.status_code == 200, r.data
     assert r.headers['Content-Disposition'].endswith('tsv')
-    assert len(r.data.strip().split('\n')) == case_count + 1
+    assert len(str(r.data, 'utf-8').strip().split('\n')) == case_count + 1
 
 
 @pytest.mark.parametrize('file_type', ['json', 'tsv'])

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -5,11 +5,11 @@ index service).
 import json
 import copy
 
-from test_endpoints import put_cgci_blgsp
+from .test_endpoints import put_cgci_blgsp
 
-from utils import assert_positive_response
-from utils import assert_negative_response
-from utils import assert_single_entity_from_response
+from .utils import assert_positive_response
+from .utils import assert_negative_response
+from .utils import assert_single_entity_from_response
 
 # Python 2 and 3 compatible
 try:

--- a/tests/unit/submission/test_bcr_xml_to_json.py
+++ b/tests/unit/submission/test_bcr_xml_to_json.py
@@ -18,7 +18,7 @@ def test_gdc_type_mappings():
 
     # parse long
     long_val = munge_property("3111118", "long")
-    assert isinstance(long_val, long)
+    assert isinstance(long_val, int)
     with pytest.raises(ValueError):
         munge_property("4.9", "long")
 


### PR DESCRIPTION
### New Features
* Updated Dockerfile to use Python3 
* ran 2to3 for syntax changes
* updated travis to ignore py2.7 failures 

### Breaking Changes
* Requires Python 3
* Updates Sheepdog to use new Indexd aliases endpoint rather than deprecated aliases endpoint (uc-cdis/indexd#248)

### Dependency updates
* bumped indexd to 2.3.0
* updated indexclient to 2.0.0
* psqlgraph to [`release/py3`](https://github.com/NCI-GDC/psqlgraph/tree/release/py3) branch to be compatible to python3 
* Updated lxml from 3.8.0 -> 4.4.0 (versions <4.0.0 are not compatible with python3)

### Deployment changes
* Fix Travis coverage reports (combine the results of all 3 tests into one coverage report).

