### PR TITLE
chore(error-handling): catch error and add details for user

### DIFF
--- a/sheepdog/transactions/transaction_base.py
+++ b/sheepdog/transactions/transaction_base.py
@@ -325,7 +325,7 @@ class TransactionBase(object):
         Record an error message.
 
         Args:
-            message (str): a message explaining what when wrong
+            message (str): a message explaining what went wrong
 
         Return:
             None

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -293,7 +293,7 @@ class UploadTransaction(TransactionBase):
             self.entities.append(entity)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(e)
-            self.record_error("Unable to parse entity")
+            self.record_error("Unable to parse entity. Details: {}".format(e))
 
 
 class BulkUploadTransaction(TransactionBase):

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -50,6 +50,10 @@ def get_node_category(node_type):
         str: node category
     """
     cls = psqlgraph.Node.get_subclass(node_type)
+    if cls is None:
+        raise UserError(
+            'Node type "{}" not found in dictionary'.format(node_type)
+        )
     return cls._dictionary.get("category")
 
 


### PR DESCRIPTION
Return a descriptive message instead of just "Unable to parse entity, Nothing to submit"

### Improvements
- When trying to submit a metadata record to a node that's not in the dictionary, user will receive an explanatory error message
