### PR TITLE
(PXP-4710) Fix/update indexd aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ script:
   # datadict and datadictwithobjid tests must run separately to allow
   # loading different datamodels
 - py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadict
-- py.test -vv --cov=sheepdog --cov-report xml tests/integration/datadictwithobjid
-- py.test -vv --cov=sheepdog --cov-report xml tests/unit
+- py.test -vv --cov=sheepdog --cov-report xml --cov-append tests/integration/datadictwithobjid
+- py.test -vv --cov=sheepdog --cov-report xml --cov-append tests/unit
 
 after_script:
 - python-codacy-coverage -r coverage.xml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ Sphinx==1.6.5
 sphinx_rtd_theme
 flasgger==0.9.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest
--e git+https://git@github.com/uc-cdis/indexd.git@2.1.0#egg=indexd
+-e git+https://git@github.com/uc-cdis/indexd.git@2.3.0#egg=indexd
 # indexd dependencies
 authutils==3.1.1
 gen3rbac==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fuzzywuzzy==0.6.1
 gen3authz==0.2.1
 graphene==2.0.1
 jsonschema==2.5.1
-lxml==3.8.0
+lxml==4.4.2
 pbr==2.0.0
 psycopg2==2.7.3.2
 python-keystoneclient==1.8.1
@@ -27,12 +27,12 @@ git+https://git@github.com/uc-cdis/cdis_oauth2client.git@chore/py3#egg=cdis_oaut
 cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 # TODO:update to pypi version once released
-git+https://git@github.com/uc-cdis/psqlgraph.git@chore/py3#egg=psqlgraph
+git+https://git@github.com/uc-cdis/psqlgraph.git@develop#egg=psqlgraph
 # required for gen3datamodel, not required for sheepdog
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-git+https://git@github.com/uc-cdis/gdcdatamodel.git@chore/py3#egg=gen3datamodel
-git+https://git@github.com/uc-cdis/indexclient.git@1.6.2#egg=indexclient
+git+https://git@github.com/uc-cdis/gdcdatamodel.git@develop#egg=gen3datamodel
+git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ cdispyutils==0.2.13
 git+https://git@github.com/uc-cdis/datamodelutils.git@chore/py3#egg=datamodelutils
 # TODO:update to pypi version once released
 # required for gen3datamodel, not required for sheepdog
-psqlgraph=3.0.0
+psqlgraph==3.0.0
 git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,6 @@ git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.2#egg=cdiserrors
 git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
+gen3datamodel==3.0.0
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 authutils==4.0.0
 boto==2.36.0
 cryptography==2.3
-git+https://git@github.com/uc-cdis/dictionaryutils.git@chore/py3#egg=dictionaryutils
+dictionaryutils==3.0.0
 envelopes==0.4
 Flask==1.1.1
 flask-cors==3.0.3

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -337,7 +337,7 @@ class FileUploadEntity(UploadEntity):
             self.object_id = str(doc.did)
             self.node._props["object_id"] = self.object_id
 
-        self._create_alias(record=alias, hashes=hashes, size=size, release="private")
+        self._create_alias(alias, doc.did)
 
     def _update_index(self):
         """
@@ -709,8 +709,8 @@ class FileUploadEntity(UploadEntity):
             return self.doc.get("file_size")
         return None
 
-    def _create_alias(self, **kwargs):
-        return self.transaction.index_client.create_alias(**kwargs)
+    def _create_alias(self, alias, did):
+        return self.transaction.index_client.add_alias_for_did(alias, did)
 
     def _create_index(self, **kwargs):
         return self.transaction.index_client.create(**kwargs)


### PR DESCRIPTION
PXP-4710: https://ctds-planx.atlassian.net/browse/PXP-4710

Update Sheepdog to use new Indexd aliases endpoint rather than deprecated aliases endpoint (https://github.com/uc-cdis/indexd/pull/248)

Background: It's not documented why, but sheepdog creates an indexd alias in the format {program-id}/{submitter-id} for every data file uploaded.

This PR also bumps versions of `indexd` and `indexclient`, and fixes some dependency issues (update `lxml` to py3 compatible version)

### Improvements
- Update Sheepdog to use new Indexd aliases endpoint rather than deprecated aliases endpoint (https://github.com/uc-cdis/indexd/pull/248)

### Dependency updates
- Update `lxml` from 3.8.0 -> 4.4.0 (versions <4.0.0 are not compatible with python3)
- Update `indexclient` version to 2.0.0
- Update `indexd` version to 2.3.0 in dev-requirements.txt

### Deployment changes
- Fix Travis coverage reports (combine the results of all 3 tests into one coverage report).
