### PR TITLE
PXP-4102 Feat/arb admin

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ flasgger==0.9.1
 -e git+https://git@github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest
 -e git+https://git@github.com/uc-cdis/indexd.git@2.3.0#egg=indexd
 # indexd dependencies
-authutils==3.1.1
+authutils==4.0.0
 gen3rbac==0.1.2
 -e git+https://git@github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://git@github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient

--- a/sheepdog/auth/__init__.py
+++ b/sheepdog/auth/__init__.py
@@ -66,6 +66,50 @@ def authorize_for_project(*required_roles):
     return wrapper
 
 
+def require_sheepdog_program_admin(func):
+    """
+    Wrap a function to allow access to the handler if the user has access to
+    the resource /services/sheepdog/submission/program (Sheepdog program admin)
+    """
+
+    @functools.wraps(func)
+    def authorize_and_call(*args, **kwargs):
+        jwt = get_jwt_from_header()
+        authz = flask.current_app.auth.auth_request(
+            jwt=jwt,
+            service="sheepdog",
+            methods="*",
+            resources=["/services/sheepdog/submission/program"],
+        )
+        if not authz:
+            raise AuthZError("Unauthorized: User must be Sheepdog program admin")
+        return func(*args, **kwargs)
+
+    return authorize_and_call
+
+
+def require_sheepdog_project_admin(func):
+    """
+    Wrap a function to allow access to the handler if the user has access to
+    the resource /services/sheepdog/submission/project (Sheepdog project admin)
+    """
+
+    @functools.wraps(func)
+    def authorize_and_call(*args, **kwargs):
+        jwt = get_jwt_from_header()
+        authz = flask.current_app.auth.auth_request(
+            jwt=jwt,
+            service="sheepdog",
+            methods="*",
+            resources=["/services/sheepdog/submission/project"],
+        )
+        if not authz:
+            raise AuthZError("Unauthorized: User must be Sheepdog project admin")
+        return func(*args, **kwargs)
+
+    return authorize_and_call
+
+
 def authorize(program, project, roles):
     resource = "/programs/{}/projects/{}".format(program, project)
     jwt = get_jwt_from_header()

--- a/sheepdog/blueprint/routes/views/__init__.py
+++ b/sheepdog/blueprint/routes/views/__init__.py
@@ -63,6 +63,7 @@ def get_programs():
     return flask.jsonify({"links": links})
 
 
+@auth.require_sheepdog_program_admin
 def root_create():
     """
     Register a program.
@@ -111,7 +112,6 @@ def root_create():
             "dbgap_accession_number": "phs000178"
         }
     """
-    auth.current_user.require_admin()
     message = None
     node_id = None
     doc = parse.parse_request_json()

--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -85,6 +85,7 @@ def get_projects(program):
 
 
 @utils.assert_program_exists
+@auth.require_sheepdog_project_admin
 def create_project(program):
     """
     Register a project.
@@ -137,7 +138,6 @@ def create_project(program):
             }
     """
     res = None
-    auth.current_user.require_admin()
     doc = utils.parse.parse_request_json()
     if not isinstance(doc, dict):
         raise UserError("Program endpoint only supports single documents")
@@ -217,6 +217,7 @@ def create_project(program):
 
 
 @utils.assert_program_exists
+@auth.require_sheepdog_program_admin
 def delete_program(program):
     """
     Delete a program given program name. If the program
@@ -237,7 +238,6 @@ def delete_program(program):
         404: Program not found.
         403: Unauthorized request.
     """
-    auth.current_user.require_admin()
     with flask.current_app.db.session_scope() as session:
         node = utils.lookup_program(flask.current_app.db, program)
         if node.edges_in:

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -465,6 +465,10 @@ def create_files_viewer(dry_run=False, reassign=False):
 
     @utils.assert_project_exists
     @auth.authorize_for_project(*auth_roles)
+    # admin only
+    # TODO: check if we need these (pauline)
+    @auth.require_sheepdog_program_admin
+    @auth.require_sheepdog_project_admin
     def file_operations(program, project, file_uuid):
         """
         Handle molecular file operations.  This will only be available once the
@@ -521,10 +525,6 @@ def create_files_viewer(dry_run=False, reassign=False):
         :reqheader X-Auth-Token: |reqheader_X-Auth-Token|
         :resheader Content-Type: |resheader_Content-Type|
         """
-
-        # admin only
-        # TODO: check if we need these (pauline)
-        auth.current_user.require_admin()
 
         headers = {
             k: v for k, v in flask.request.headers.items() if v and k != "X-Auth-Token"

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -1102,6 +1102,7 @@ def create_clinical_viewer(dry_run=False):
 
 
 @utils.assert_project_exists
+@auth.require_sheepdog_project_admin
 def delete_project(program, project):
     """
     Delete project under a specific program
@@ -1122,7 +1123,6 @@ def delete_project(program, project):
         404: Resource not found.
         403: Unauthorized request.
     """
-    auth.current_user.require_admin()
     with flask.current_app.db.session_scope() as session:
         node = utils.lookup_project(flask.current_app.db, program, project)
         if node.edges_in:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ from tests import utils
 
 
 SUBMITTER_USERNAME = "submitter"
-ADMIN_USERNAME = "admin"
 
 
 @pytest.fixture(scope="session")
@@ -84,11 +83,6 @@ def submitter(create_user_header):
 @pytest.fixture()
 def submitter_name():
     return SUBMITTER_USERNAME
-
-
-@pytest.fixture()
-def admin(create_user_header):
-    return create_user_header(ADMIN_USERNAME, is_admin=True)
 
 
 @pytest.yield_fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,6 @@ def create_user_header(encoded_jwt):
         user_properties = {
             "id": 1,
             "username": username,
-            "is_admin": False,
             "policies": [],
             "google_proxy_group_id": None,
         }

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -166,8 +166,8 @@ def pg_driver(request, client):
 
 
 @pytest.fixture()
-def cgci_blgsp(client, admin):
-    put_cgci_blgsp(client, admin)
+def cgci_blgsp(client, submitter):
+    put_cgci_blgsp(client, submitter)
 
 
 @pytest.fixture()

--- a/tests/integration/datadict/submission/test_admin_endpoints.py
+++ b/tests/integration/datadict/submission/test_admin_endpoints.py
@@ -54,7 +54,7 @@ def post_blgsp_files(client, headers):
 
 @pytest.mark.parametrize(
     "headers,status_code,to_delete",
-    [("submitter", 403, None), ("admin", 200, True), ("admin", 200, False)],
+    [("submitter", 403, None), ("submitter", 200, True), ("submitter", 200, False)],
 )
 def test_to_delete(
     headers,

--- a/tests/integration/datadict/submission/test_admin_endpoints.py
+++ b/tests/integration/datadict/submission/test_admin_endpoints.py
@@ -94,37 +94,39 @@ def test_to_delete(
         assert sur_node.sysan.get("to_delete") is to_delete
 
 
-def do_reassign(client, headers):
-    """Perform the http reassign action
+def test_reassign(
+    client, pg_driver, cgci_blgsp, index_client, submitter, require_index_exists_off
+):
+    """Try to reassign a node's remote URL
 
-    Args:
-        client (pytest.Fixture): Allows you to mock http requests through flask
-        headers (dict): http headers with token
-
-    Returns:
-        requests.Response: http response from doing reassign request
-        string: did
-        string: s3 url that you changed it to
+    Url:
+        PUT: /admin/<program>/<project>/files/<file_uuid>/reassign
+        data: {"s3_url": "s3://whatever/you/want"}
     """
+    # Does not test authz.
 
-    entities = post_blgsp_files(client, headers)
+    # Set up for http reassign action
+    entities = post_blgsp_files(client, submitter)
     dids = entities["submitted_unaligned_reads"]
     s3_url = "s3://whatever/you/want"
-
     reassign_path = create_blgsp_url("/files/{}/reassign".format(dids[0]))
     data = json.dumps({"s3_url": s3_url})
+    # http reassign action
+    resp = client.put(reassign_path, headers=submitter, data=data)
 
-    return client.put(reassign_path, headers=headers, data=data), dids[0], s3_url
+    assert resp.status_code == 200, resp.data
+    assert index_client.get(dids[0]), "Did not register with indexd?"
+    assert s3_url in index_client.get(dids[0]).urls, "Did not successfully reassign"
 
 
-def test_reassign_with_admin(
+def test_reassign_unauthorized(
     client,
     pg_driver,
     cgci_blgsp,
     submitter,
     index_client,
-    admin,
     require_index_exists_off,
+    mock_arborist_requests,
 ):
     """Try to reassign a node's remote URL
 
@@ -132,25 +134,21 @@ def test_reassign_with_admin(
         PUT: /admin/<program>/<project>/files/<file_uuid>/reassign
         data: {"s3_url": "s3://whatever/you/want"}
     """
+    # Just checks that this is guarded with an Arborist auth request.
+    # (Does not check that the auth request is for the Sheepdog admin policy.)
 
-    resp, did, s3_url = do_reassign(client, admin)
-    assert resp.status_code == 200, resp.data
-    assert index_client.get(did), "Did not register with indexd?"
-    assert s3_url in index_client.get(did).urls, "Did not successfully reassign"
+    # Set up for http reassign action
+    entities = post_blgsp_files(client, submitter)
+    dids = entities["submitted_unaligned_reads"]
+    s3_url = "s3://whatever/you/want"
+    reassign_path = create_blgsp_url("/files/{}/reassign".format(dids[0]))
+    data = json.dumps({"s3_url": s3_url})
+    # Mock arborist auth requests so they return false
+    mock_arborist_requests(authorized=False)
+    # http reassign action
+    resp = client.put(reassign_path, headers=submitter, data=data)
 
-
-def test_reassign_without_admin(
-    client, pg_driver, cgci_blgsp, submitter, index_client, require_index_exists_off
-):
-    """Try to reassign a node's remote URL
-
-    Url:
-        PUT: /admin/<program>/<project>/files/<file_uuid>/reassign
-        data: {"s3_url": "s3://whatever/you/want"}
-    """
-
-    resp, did, s3_url = do_reassign(client, submitter)
     assert resp.status_code == 403, resp.data
-    assert index_client.get(did), "Index should have been created."
-    assert len(index_client.get(did).urls) == 0, "No files have been uploaded"
-    assert s3_url not in index_client.get(did).urls, "Should not have reassigned"
+    assert index_client.get(dids[0]), "Index should have been created."
+    assert len(index_client.get(dids[0]).urls) == 0, "No files have been uploaded"
+    assert s3_url not in index_client.get(dids[0]).urls, "Should not have reassigned"

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -389,8 +389,8 @@ def test_put_dry_run(client, pg_driver, cgci_blgsp, submitter):
         assert not pg_driver.nodes(md.Experiment).first()
 
 
-def test_incorrect_project_error(client, pg_driver, cgci_blgsp, submitter, admin):
-    put_tcga_brca(client, admin)
+def test_incorrect_project_error(client, pg_driver, cgci_blgsp, submitter):
+    put_tcga_brca(client, submitter)
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
@@ -422,7 +422,7 @@ def test_incorrect_project_error(client, pg_driver, cgci_blgsp, submitter, admin
 
 
 def test_insert_multiple_parents_and_export_by_ids(
-    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off, admin
+    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):
     post_example_entities_together(client, submitter)
     path = BLGSP_PATH
@@ -452,9 +452,9 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
 
 
 def test_disallow_cross_project_references(
-    client, pg_driver, cgci_blgsp, submitter, admin
+    client, pg_driver, cgci_blgsp, submitter
 ):
-    put_tcga_brca(client, admin)
+    put_tcga_brca(client, submitter)
     data = {
         "progression_or_recurrence": "unknown",
         "classification_of_tumor": "other",

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -123,15 +123,21 @@ def add_and_get_new_experimental_metadata_count(pg_driver):
     return experimental_metadata_count
 
 
-def test_program_creation_endpoint(client, pg_driver, admin):
-    resp = put_cgci(client, auth=admin)
+def test_program_creation_endpoint(client, pg_driver, submitter):
+    # Does not test authz.
+    resp = put_cgci(client, auth=submitter)
     assert resp.status_code == 200, resp.data
     print(resp.data)
     resp = client.get("/v0/submission/")
     assert resp.json["links"] == ["/v0/submission/CGCI"], resp.json
 
 
-def test_program_creation_without_admin_token(client, pg_driver, submitter):
+def test_program_creation_unauthorized(
+    client, pg_driver, submitter, mock_arborist_requests
+):
+    # Just checks that this is guarded with an Arborist auth request.
+    # (Does not check that the auth request is for the Sheepdog admin policy.)
+    mock_arborist_requests(authorized=False)
     path = "/v0/submission/"
     headers = submitter
     data = json.dumps({"name": "CGCI", "type": "program"})
@@ -147,8 +153,9 @@ def test_program_creation_endpoint_for_program_not_supported(
     assert resp.status_code == 404
 
 
-def test_project_creation_endpoint(client, pg_driver, admin):
-    resp = put_cgci_blgsp(client, auth=admin)
+def test_project_creation_endpoint(client, pg_driver, submitter):
+    # Does not test authz.
+    resp = put_cgci_blgsp(client, auth=submitter)
     assert resp.status_code == 200
     resp = client.get("/v0/submission/CGCI/")
     with pg_driver.session_scope():
@@ -158,9 +165,15 @@ def test_project_creation_endpoint(client, pg_driver, admin):
     assert resp.json["links"] == ["/v0/submission/CGCI/BLGSP"], resp.json
 
 
-def test_project_creation_without_admin_token(client, pg_driver, submitter, admin):
-    put_cgci(client, admin)
+def test_project_creation_unauthorized(
+    client, pg_driver, submitter, mock_arborist_requests
+):
+    # Just checks that this is guarded with an Arborist auth request.
+    # (Does not check that the auth request is for the Sheepdog admin policy.)
+    put_cgci(client, submitter)
     path = "/v0/submission/CGCI/"
+
+    mock_arborist_requests(authorized=False)
     resp = client.put(
         path,
         headers=submitter,

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -451,9 +451,7 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
         assert ct is not None, case.props
 
 
-def test_disallow_cross_project_references(
-    client, pg_driver, cgci_blgsp, submitter
-):
+def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submitter):
     put_tcga_brca(client, submitter)
     data = {
         "progression_or_recurrence": "unknown",

--- a/tests/integration/datadict/submission/test_upload.py
+++ b/tests/integration/datadict/submission/test_upload.py
@@ -198,9 +198,7 @@ def test_data_file_not_indexed_id_provided(
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["id"] = DEFAULT_UUID
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # index creation
     assert create_index.call_count == 1
@@ -324,9 +322,7 @@ def test_data_file_already_indexed_id_provided(
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["id"] = document.did
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called
@@ -1054,9 +1050,7 @@ def test_can_submit_data_file_with_asterisk_json(
     for key in file.keys():
         file["*{}".format(key)] = file.pop(key)
 
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -161,8 +161,8 @@ def pg_driver(request, client):
 
 
 @pytest.fixture()
-def cgci_blgsp(client, admin):
-    put_cgci_blgsp(client, admin)
+def cgci_blgsp(client, submitter):
+    put_cgci_blgsp(client, submitter)
 
 
 @pytest.fixture()

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -476,9 +476,7 @@ def test_timestamps(client, pg_driver, cgci_blgsp, submitter):
         assert ct is not None, case.props
 
 
-def test_disallow_cross_project_references(
-    client, pg_driver, cgci_blgsp, submitter
-):
+def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submitter):
     put_tcga_brca(client, submitter)
     data = {
         "progression_or_recurrence": "unknown",

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -153,9 +153,7 @@ def test_data_file_not_indexed_id_provided(
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["object_id"] = DEFAULT_UUID
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # index creation
     assert create_index.call_count == 1
@@ -284,9 +282,7 @@ def test_data_file_already_indexed_id_provided(
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["id"] = document.did
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called
@@ -560,9 +556,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called
@@ -963,9 +957,7 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called
@@ -1033,9 +1025,7 @@ def test_data_file_already_indexed_object_id_provided_no_hash(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    resp = submit_metadata_file(
-        client, pg_driver, submitter, cgci_blgsp, data=file
-    )
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=file)
 
     # no index or alias creation
     assert not create_index.called

--- a/tests/integration/datadictwithobjid/submission/test_upload.py
+++ b/tests/integration/datadictwithobjid/submission/test_upload.py
@@ -43,8 +43,8 @@ DEFAULT_METADATA_FILE = {
 }
 
 
-def submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp):
-    put_cgci_blgsp(client, admin)
+def submit_first_experiment(client, pg_driver, submitter, cgci_blgsp):
+    put_cgci_blgsp(client, submitter)
 
     # first submit experiment
     data = json.dumps(
@@ -58,9 +58,9 @@ def submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp):
     assert resp.status_code == 200, resp.data
 
 
-def submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp, data=None):
+def submit_metadata_file(client, pg_driver, submitter, cgci_blgsp, data=None):
     data = data or DEFAULT_METADATA_FILE
-    put_cgci_blgsp(client, admin)
+    put_cgci_blgsp(client, submitter)
     data = json.dumps(data)
     resp = client.put(BLGSP_PATH, headers=submitter, data=data)
     return resp
@@ -81,7 +81,6 @@ def test_data_file_not_indexed(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
     require_index_exists_off,
@@ -89,12 +88,12 @@ def test_data_file_not_indexed(
     """
     Test node and data file creation when neither exist and no ID is provided.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     get_index_uuid.return_value = None
     get_index_hash.return_value = None
 
-    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # index creation
     assert create_index.call_count == 1
@@ -139,7 +138,6 @@ def test_data_file_not_indexed_id_provided(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
     require_index_exists_off,
@@ -148,7 +146,7 @@ def test_data_file_not_indexed_id_provided(
     Test node and data file creation when neither exist and an ID is provided.
     That ID should be used for the node and file index creation
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     get_index_uuid.return_value = None
     get_index_hash.return_value = None
@@ -156,7 +154,7 @@ def test_data_file_not_indexed_id_provided(
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["object_id"] = DEFAULT_UUID
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+        client, pg_driver, submitter, cgci_blgsp, data=file
     )
 
     # index creation
@@ -199,7 +197,6 @@ def test_data_file_already_indexed(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -208,7 +205,7 @@ def test_data_file_already_indexed(
     no ID is provided. sheepdog should fall back on the hash/size of the file
     to find it in indexing service.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -224,7 +221,7 @@ def test_data_file_already_indexed(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # no index or alias creation
     assert not create_index.called
@@ -261,7 +258,6 @@ def test_data_file_already_indexed_id_provided(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -269,7 +265,7 @@ def test_data_file_already_indexed_id_provided(
     Test submitting when the file is already indexed in the index client and
     an id is provided in the submission.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -289,7 +285,7 @@ def test_data_file_already_indexed_id_provided(
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     file["id"] = document.did
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+        client, pg_driver, submitter, cgci_blgsp, data=file
     )
 
     # no index or alias creation
@@ -322,7 +318,6 @@ def test_data_file_update_url(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -330,7 +325,7 @@ def test_data_file_update_url(
     Test submitting the same data again but updating the URL field (should
     get added to the indexed file in index service).
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -347,14 +342,14 @@ def test_data_file_update_url(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # now submit again but change url
     new_url = "some/new/url/location/to/add"
     updated_file = copy.deepcopy(DEFAULT_METADATA_FILE)
     updated_file["urls"] = new_url
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -388,7 +383,6 @@ def test_data_file_update_multiple_urls(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -396,7 +390,7 @@ def test_data_file_update_multiple_urls(
     Test submitting the same data again but updating the URL field (should
     get added to the indexed file in index service).
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -413,7 +407,7 @@ def test_data_file_update_multiple_urls(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # now submit again but change url
     new_url = "some/new/url/location/to/add"
@@ -423,7 +417,7 @@ def test_data_file_update_multiple_urls(
     # comma separated list of urls INCLUDING the url that's already there
     updated_file["urls"] = DEFAULT_URL + "," + new_url + "," + another_new_url
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -460,7 +454,6 @@ def test_data_file_update_url_id_provided(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -468,7 +461,7 @@ def test_data_file_update_url_id_provided(
     Test submitting the same data again (with the id provided) and updating the
     URL field (should get added to the indexed file in index service).
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -485,7 +478,7 @@ def test_data_file_update_url_id_provided(
 
     get_index_uuid.side_effect = get_index_by_uuid
 
-    submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # now submit again but change url
     new_url = "some/new/url/location/to/add"
@@ -493,7 +486,7 @@ def test_data_file_update_url_id_provided(
     updated_file["object_id"] = "14fd1746-61bb-401a-96d2-342cfaf70000"
     updated_file["urls"] = new_url
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -529,7 +522,6 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     submitter_name,
     cgci_blgsp,
@@ -543,7 +535,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     and uploader field should have been updated as part of the data upload
     flow.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     # provide the object_id of an existing indexed file
@@ -569,7 +561,7 @@ def test_data_file_already_indexed_object_id_provided_hash_match(
     get_index_uuid.side_effect = get_index_by_uuid
 
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+        client, pg_driver, submitter, cgci_blgsp, data=file
     )
 
     # no index or alias creation
@@ -612,7 +604,6 @@ def test_data_file_update_url_invalid_id(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -624,7 +615,7 @@ def test_data_file_update_url_invalid_id(
     FIXME: the 1:1 between node id and index/file id is temporary so this
            test may need to be modified in the future
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = "14fd1746-61bb-401a-96d2-342cfaf70000"
@@ -634,7 +625,7 @@ def test_data_file_update_url_invalid_id(
     # the uuid provided doesn't have a matching indexed file
     get_index_uuid.return_value = None
 
-    submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # now submit again but change url
     new_url = "some/new/url/location/to/add"
@@ -642,7 +633,7 @@ def test_data_file_update_url_invalid_id(
     updated_file["urls"] = new_url
     updated_file["id"] = DEFAULT_UUID
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -673,7 +664,6 @@ def test_data_file_update_url_id_provided_different_file_not_indexed(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -690,7 +680,7 @@ def test_data_file_update_url_id_provided_different_file_not_indexed(
 
     FIXME At the moment, we do not allow updating like this
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = DEFAULT_UUID
@@ -700,7 +690,7 @@ def test_data_file_update_url_id_provided_different_file_not_indexed(
     # index yeilds no match given hash/size
     get_index_hash.return_value = None
 
-    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
     assert_single_entity_from_response(resp)
 
     # now submit again but change url
@@ -711,7 +701,7 @@ def test_data_file_update_url_id_provided_different_file_not_indexed(
     updated_file["md5sum"] = DEFAULT_FILE_HASH.replace("0", "2")
     updated_file["file_size"] = DEFAULT_FILE_SIZE + 1
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -742,7 +732,6 @@ def test_data_file_update_url_different_file_not_indexed(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -762,7 +751,7 @@ def test_data_file_update_url_different_file_not_indexed(
     the submitter_id/project). There is already a match for that, BUT
     the provided file hash/size is different than the previously submitted one.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document = MagicMock()
     document.did = DEFAULT_UUID
@@ -772,7 +761,7 @@ def test_data_file_update_url_different_file_not_indexed(
     # index yeilds no match given hash/size
     get_index_hash.return_value = None
 
-    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     entity = assert_single_entity_from_response(resp)
 
@@ -784,7 +773,7 @@ def test_data_file_update_url_different_file_not_indexed(
     updated_file["md5sum"] = DEFAULT_FILE_HASH.replace("0", "2")
     updated_file["file_size"] = DEFAULT_FILE_SIZE + 1
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -815,7 +804,6 @@ def test_data_file_update_url_id_provided_different_file_already_indexed(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -831,7 +819,7 @@ def test_data_file_update_url_id_provided_different_file_already_indexed(
 
     FIXME At the moment, we do not allow updating like this
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     document_with_id = MagicMock()
     document_with_id.did = DEFAULT_UUID
@@ -844,7 +832,7 @@ def test_data_file_update_url_id_provided_different_file_already_indexed(
     get_index_uuid.return_value = document_with_id
     get_index_hash.return_value = different_file_matching_hash_and_size
 
-    submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
 
     # now submit again but change url
     new_url = "some/new/url/location/to/add"
@@ -854,7 +842,7 @@ def test_data_file_update_url_id_provided_different_file_already_indexed(
     updated_file["md5sum"] = DEFAULT_FILE_HASH.replace("0", "2")
     updated_file["file_size"] = DEFAULT_FILE_SIZE + 1
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=updated_file
+        client, pg_driver, submitter, cgci_blgsp, data=updated_file
     )
 
     # no index or alias creation
@@ -887,7 +875,6 @@ def test_create_file_no_required_index(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
     require_index_exists_on,
@@ -896,14 +883,14 @@ def test_create_file_no_required_index(
     With REQUIRE_FILE_INDEX_EXISTS = True.
     Test submitting a data file that does not exist in indexd (should raise an error and should not create an index or an alias).
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     # no record in indexd for this file
     get_index_uuid.return_value = None
     get_index_hash.return_value = None
 
     # creating raises an error
-    resp = submit_metadata_file(client, pg_driver, admin, submitter, cgci_blgsp)
+    resp = submit_metadata_file(client, pg_driver, submitter, cgci_blgsp)
     assert resp.status_code == 400
 
     # no index or alias creation
@@ -939,7 +926,6 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -952,7 +938,7 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     The submission should fail. The acl and uploader field should NOT have
     been updated.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     # provide the object_id of an existing indexed file
@@ -978,7 +964,7 @@ def test_data_file_already_indexed_object_id_provided_hash_no_match(
     get_index_uuid.side_effect = get_index_by_uuid
 
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+        client, pg_driver, submitter, cgci_blgsp, data=file
     )
 
     # no index or alias creation
@@ -1009,7 +995,6 @@ def test_data_file_already_indexed_object_id_provided_no_hash(
     get_index_hash,
     client,
     pg_driver,
-    admin,
     submitter,
     cgci_blgsp,
 ):
@@ -1023,7 +1008,7 @@ def test_data_file_already_indexed_object_id_provided_no_hash(
     The submission should fail. The acl and uploader field should NOT have
     been updated.
     """
-    submit_first_experiment(client, pg_driver, admin, submitter, cgci_blgsp)
+    submit_first_experiment(client, pg_driver, submitter, cgci_blgsp)
 
     file = copy.deepcopy(DEFAULT_METADATA_FILE)
     # provide the object_id of an existing indexed file
@@ -1049,7 +1034,7 @@ def test_data_file_already_indexed_object_id_provided_no_hash(
     get_index_uuid.side_effect = get_index_by_uuid
 
     resp = submit_metadata_file(
-        client, pg_driver, admin, submitter, cgci_blgsp, data=file
+        client, pg_driver, submitter, cgci_blgsp, data=file
     )
 
     # no index or alias creation

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,7 +97,6 @@ def generate_signed_access_token(
         "context": {
             "user": {
                 "name": user.username,
-                "is_admin": user.is_admin,
                 "google": {"proxy_group": user.google_proxy_group_id},
             }
         },


### PR DESCRIPTION
Switches Sheepdog authz handling of program/project CRUD to centralized auth/Arborist.

See https://github.com/uc-cdis/commons-users/pull/810 for new Sheepdog admin policy.

(For QAs' benefit) How to test:
- See PR linked above for example of how to toggle for a given user the old `admin: true/false` and the new admin policy 
- Verify that the API behaves according to this matrix:
```
    User DOES have Sheepdog admin policy: All CRUD authorized.
        Admin is FALSE:
            Create program: Authorized
            Delete program: Authorized
            Create project: Authorized
            Delete project: Authorized
        Admin is TRUE:
            Create program: Authorized
            Delete program: Authorized
            Create project: Authorized
            Delete project: Authorized
    User does NOT have Sheepdog admin policy: All CRUD not authorized.
    (Also check that they are 403s in particular)
        Admin is FALSE:
            Create program: Unauthorized
            Delete program: Unauthorized
            Create project: Unauthorized
            Delete project: Unauthorized
        Admin is TRUE:
            Create program: Unauthorized
            Delete program: Unauthorized
            Create project: Unauthorized
            Delete project: Unauthorized
```

### New Features
Switch checks guarding program/project CRUD to centralized auth (instead of checking for "admin" in JWT, check for Sheepdog admin policy in Arborist)

### Breaking Changes
Having admin: true in user.yaml no longer allows a user to do program/project CRUD in Sheepdog. Users now need to have the Sheepdog admin policy in Arborist. 

### Deployment changes
The environment's user.yaml needs to be updated to add the new Sheepdog admin policy/resources/roles; for each user that has admin: true, grant them the new policy. See https://github.com/uc-cdis/commons-users/pull/810 for an example.
