### PR TITLE
PXP-5663 Fix/exporting none issue

### DIFF
--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -821,7 +821,9 @@ def export_all(node_label, project_id, file_format, db, without_id):
 
         # ``props`` is just a list of strings of the properties of the node
         # class that should go in the result.
-        list_obj = result_to_dictionary(query, titles_non_linked, titles_linked, file_format)
+        list_obj = result_to_dictionary(
+            query, titles_non_linked, titles_linked, file_format
+        )
         props = [format_prop(t) for t in titles_non_linked]
         if file_format == "json":
             yield '{ "data": ['

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -153,9 +153,10 @@ def list_to_comma_string(val, file_format):
     """
 
     if val is None:
-        if file_format == "tsv":
-            return ""
-        return val
+        """ If a field is empty we must replace it with an empty string for tsv/csv exports and leave it as None for json exports """
+        if file_format == "json":
+            return val
+        return ""
 
     if isinstance(val, list):
         val = ",".join(val)

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -144,7 +144,7 @@ def get_node_non_link_json(node, props):
     return entity
 
 
-def list_to_comma_string(val):
+def list_to_comma_string(val, file_format):
     """
     Handle array fields by converting them to a comma-separated string.
 
@@ -153,7 +153,9 @@ def list_to_comma_string(val):
     """
 
     if val is None:
-        return ""
+        if file_format == "tsv":
+            return ""
+        return val
 
     if isinstance(val, list):
         val = ",".join(val)
@@ -819,7 +821,7 @@ def export_all(node_label, project_id, file_format, db, without_id):
 
         # ``props`` is just a list of strings of the properties of the node
         # class that should go in the result.
-        list_obj = result_to_dictionary(query, titles_non_linked, titles_linked)
+        list_obj = result_to_dictionary(query, titles_non_linked, titles_linked, file_format)
         props = [format_prop(t) for t in titles_non_linked]
         if file_format == "json":
             yield '{ "data": ['
@@ -875,7 +877,7 @@ def result_to_delimited_file(props_values, file_format):
     return splitter.join(props_values)
 
 
-def result_to_dictionary(query, titles_non_linked, titles_linked):
+def result_to_dictionary(query, titles_non_linked, titles_linked, file_format):
     props = [format_prop(t) for t in titles_non_linked]
     all_results = {}
     link_props_split = list(map(format_linked_prop, titles_linked))
@@ -884,7 +886,7 @@ def result_to_dictionary(query, titles_non_linked, titles_linked):
         node_id = node["node_id"]
         if node_id not in all_results:
             all_results[node_id] = {
-                prop: list_to_comma_string(node[prop]) for prop in props
+                prop: list_to_comma_string(node[prop], file_format) for prop in props
             }
         saved_obj = all_results[node_id]
         linked_fields = defaultdict(defaultdict)

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -153,7 +153,7 @@ def list_to_comma_string(val):
     """
 
     if val is None:
-        return val
+        return ""
 
     if isinstance(val, list):
         val = ",".join(val)

--- a/tests/integration/datadict/submission/data/experimental_metadata.json
+++ b/tests/integration/datadict/submission/data/experimental_metadata.json
@@ -10,6 +10,5 @@
       {"submitter_id": "BLGSP-71-experiment-02"}
     ],
     "data_category": "data_file",
-    "file_size": 42,
-    "state_comment": "comments"
+    "file_size": 42
 }

--- a/tests/integration/datadict/submission/data/experimental_metadata.json
+++ b/tests/integration/datadict/submission/data/experimental_metadata.json
@@ -10,5 +10,6 @@
       {"submitter_id": "BLGSP-71-experiment-02"}
     ],
     "data_category": "data_file",
-    "file_size": 42
+    "file_size": 42,
+    "state_comment": "comments"
 }

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -829,12 +829,11 @@ def test_export_all_node_types_and_resubmit_tsv(
     print(json.dumps(json.loads(resp.data), indent=4, sort_keys=True))
     assert resp.status_code == 201, resp.data
 
+
 def test_export_all_node_types_and_resubmit_json2(
     client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):
-    js_id_data = do_test_export(
-        client, pg_driver, submitter, "experiment", "json"
-    )
+    js_id_data = do_test_export(client, pg_driver, submitter, "experiment", "json")
     js_data = json.loads(
         get_export_data(client, submitter, "experiment", "json", True).data
     )
@@ -848,12 +847,9 @@ def test_export_all_node_types_and_resubmit_json2(
 def test_export_all_node_types_and_resubmit_tsv2(
     client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):
-    str_id_data = do_test_export(
-        client, pg_driver, submitter, "experiment", "tsv"
-    )
+    str_id_data = do_test_export(client, pg_driver, submitter, "experiment", "tsv")
     str_data = str(
-        get_export_data(client, submitter, "experiment", "tsv", True).data,
-        "utf-8",
+        get_export_data(client, submitter, "experiment", "tsv", True).data, "utf-8",
     )
 
     headers = submitter

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -829,6 +829,22 @@ def test_export_all_node_types_and_resubmit_tsv(
     print(json.dumps(json.loads(resp.data), indent=4, sort_keys=True))
     assert resp.status_code == 201, resp.data
 
+def test_export_all_node_types_and_resubmit_json2(
+    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
+):
+    js_id_data = do_test_export(
+        client, pg_driver, submitter, "experiment", "json"
+    )
+    js_data = json.loads(
+        get_export_data(client, submitter, "experiment", "json", True).data
+    )
+
+    headers = submitter
+    resp = client.put(BLGSP_PATH, headers=headers, data=json.dumps(js_data["data"]))
+    print(json.dumps(json.loads(resp.data), indent=4, sort_keys=True))
+    assert resp.status_code == 200, resp.data
+
+
 def test_export_all_node_types_and_resubmit_tsv2(
     client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -841,11 +841,11 @@ def test_export_all_node_types_and_resubmit_json_with_empty_field(
     js_data = json.loads(
         get_export_data(client, submitter, "experiment", "json", True).data
     )
-    nonempty = ['project_id', 'submitter_id', 'projects', 'type']
+    nonempty = ["project_id", "submitter_id", "projects", "type"]
     print(js_data)
-    for key in js_data['data'][0].keys():
+    for key in js_data["data"][0].keys():
         assert key in nonempty
-    for key in js_data['data'][1].keys():
+    for key in js_data["data"][1].keys():
         assert key in nonempty
 
     headers = submitter
@@ -864,14 +864,14 @@ def test_export_all_node_types_and_resubmit_tsv_with_empty_field(
     str_id_data = do_test_export(client, pg_driver, submitter, "experiment", "tsv")
     str_data = get_export_data(client, submitter, "experiment", "tsv", True).data
 
-    nonempty = ['project_id', 'submitter_id', 'projects.code', 'type']
+    nonempty = ["project_id", "submitter_id", "projects.code", "type"]
     tsv_output = csv.DictReader(StringIO(str_data.decode("utf-8")), delimiter="\t")
     row = next(tsv_output)
-    for k,v in row.items():
+    for k, v in row.items():
         if k not in nonempty:
             assert v == ""
     row = next(tsv_output)
-    for k,v in row.items():
+    for k, v in row.items():
         if k not in nonempty:
             assert v == ""
 

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -1027,7 +1027,7 @@ def test_zero_decimal_float(client, pg_driver, cgci_blgsp, submitter):
     Test that float values with a zero decimal are accepted by Sheepdog
     for properites of type "number" even if they look like integers. 
     We are testing with TSV because the str values from TSV are cast 
-    to the proper type by Sheepdog. 
+    to the proper type by Sheepdog.  
     """
     resp = client.put(
         BLGSP_PATH,

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -843,10 +843,9 @@ def test_export_all_node_types_and_resubmit_json_with_empty_field(
     )
     nonempty = ["project_id", "submitter_id", "projects", "type"]
     print(js_data)
-    for key in js_data["data"][0].keys():
-        assert key in nonempty
-    for key in js_data["data"][1].keys():
-        assert key in nonempty
+    for data in js_data["data"]:
+        for key in data.keys():
+            assert key in nonempty
 
     headers = submitter
     resp = client.put(BLGSP_PATH, headers=headers, data=json.dumps(js_data["data"]))
@@ -866,14 +865,10 @@ def test_export_all_node_types_and_resubmit_tsv_with_empty_field(
 
     nonempty = ["project_id", "submitter_id", "projects.code", "type"]
     tsv_output = csv.DictReader(StringIO(str_data.decode("utf-8")), delimiter="\t")
-    row = next(tsv_output)
-    for k, v in row.items():
-        if k not in nonempty:
-            assert v == ""
-    row = next(tsv_output)
-    for k, v in row.items():
-        if k not in nonempty:
-            assert v == ""
+    for row in tsv_output:
+        for k, v in row.items():
+            if k not in nonempty:
+                assert v == ""
 
     str_data = str(str_data, "utf-8")
     headers = submitter

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -830,13 +830,23 @@ def test_export_all_node_types_and_resubmit_tsv(
     assert resp.status_code == 201, resp.data
 
 
-def test_export_all_node_types_and_resubmit_json2(
+def test_export_all_node_types_and_resubmit_json_with_empty_field(
     client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):
+    """
+    Test that we can export an entity with empty fields (as json) then resubmit it. 
+    The exported entity should have the empty fields omitted. 
+    """
     js_id_data = do_test_export(client, pg_driver, submitter, "experiment", "json")
     js_data = json.loads(
         get_export_data(client, submitter, "experiment", "json", True).data
     )
+    nonempty = ['project_id', 'submitter_id', 'projects', 'type']
+    print(js_data)
+    for key in js_data['data'][0].keys():
+        assert key in nonempty
+    for key in js_data['data'][1].keys():
+        assert key in nonempty
 
     headers = submitter
     resp = client.put(BLGSP_PATH, headers=headers, data=json.dumps(js_data["data"]))
@@ -844,14 +854,28 @@ def test_export_all_node_types_and_resubmit_json2(
     assert resp.status_code == 200, resp.data
 
 
-def test_export_all_node_types_and_resubmit_tsv2(
+def test_export_all_node_types_and_resubmit_tsv_with_empty_field(
     client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
 ):
+    """
+    Test that we can export an entity with empty fields (as tsv) then resubmit it. The empty values 
+    of the exported entity should be empty strings.
+    """
     str_id_data = do_test_export(client, pg_driver, submitter, "experiment", "tsv")
-    str_data = str(
-        get_export_data(client, submitter, "experiment", "tsv", True).data, "utf-8",
-    )
+    str_data = get_export_data(client, submitter, "experiment", "tsv", True).data
 
+    nonempty = ['project_id', 'submitter_id', 'projects.code', 'type']
+    tsv_output = csv.DictReader(StringIO(str_data.decode("utf-8")), delimiter="\t")
+    row = next(tsv_output)
+    for k,v in row.items():
+        if k not in nonempty:
+            assert v == ""
+    row = next(tsv_output)
+    for k,v in row.items():
+        if k not in nonempty:
+            assert v == ""
+
+    str_data = str(str_data, "utf-8")
     headers = submitter
     headers["Content-Type"] = "text/tsv"
     resp = client.put(BLGSP_PATH, headers=headers, data=str_data)

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -826,7 +826,25 @@ def test_export_all_node_types_and_resubmit_tsv(
     headers = submitter
     headers["Content-Type"] = "text/tsv"
     resp = client.post(BLGSP_PATH, headers=headers, data=str_data)
+    print(json.dumps(json.loads(resp.data), indent=4, sort_keys=True))
     assert resp.status_code == 201, resp.data
+
+def test_export_all_node_types_and_resubmit_tsv2(
+    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
+):
+    str_id_data = do_test_export(
+        client, pg_driver, submitter, "experiment", "tsv"
+    )
+    str_data = str(
+        get_export_data(client, submitter, "experiment", "tsv", True).data,
+        "utf-8",
+    )
+
+    headers = submitter
+    headers["Content-Type"] = "text/tsv"
+    resp = client.put(BLGSP_PATH, headers=headers, data=str_data)
+    print(json.dumps(json.loads(resp.data), indent=4, sort_keys=True))
+    assert resp.status_code == 200, resp.data
 
 
 def test_export_all_node_types_json(


### PR DESCRIPTION

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### Bug Fixes
When exporting entities as a tsv file Null values would have 'None' instead of an empty string. This would cause an error when resubmitting. Fixed by checking file format and making Null values an empty string when the format is tsv. 