### PR TITLE
(PXP-6580): fix data submission by only writing acl and authz iff both are empty

### DIFF
--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -58,7 +58,7 @@ class FileUploadEntity(UploadEntity):
            index service
         2) If an id is provided in the submission we can look up that uuid in
            index service
-        2) The hash/file_size combo provided should be unique in the index
+        3) The hash/file_size combo provided should be unique in the index
            service for each file
 
     Handling Relationship Between Graph Node and Indexed File:

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -112,7 +112,7 @@ class FileUploadEntity(UploadEntity):
         self.file_by_hash = None
         self.object_id = None
         self.urls = []
-        self.should_update_acl_uploader = False
+        self.should_update_acl_and_authz = False
 
     def parse(self, doc):
         """
@@ -154,7 +154,7 @@ class FileUploadEntity(UploadEntity):
                     hasattr(self.file_by_uuid, "authz") and self.file_by_uuid.authz
                 )
             ):
-                self.should_update_acl_uploader = True
+                self.should_update_acl_and_authz = True
         else:
             self._set_node_and_file_ids()
 
@@ -232,7 +232,7 @@ class FileUploadEntity(UploadEntity):
         try:
             if role == "create":
                 # data upload flow: update the blank record in indexd
-                if self.should_update_acl_uploader:
+                if self.should_update_acl_and_authz:
                     self._update_acl_uploader_for_file()
 
                     # Temporary fix to update authz field in index record

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -149,8 +149,10 @@ class FileUploadEntity(UploadEntity):
         if self.use_object_id(self.entity_type) and self.object_id and self.file_exists:
             if (
                 self._is_valid_hash_size_for_file()
-                and not self.file_by_uuid.acl
-                and not self.file_by_uuid.authz
+                and not (hasattr(self.file_by_uuid, "acl") and self.file_by_uuid.acl)
+                and not (
+                    hasattr(self.file_by_uuid, "authz") and self.file_by_uuid.authz
+                )
             ):
                 self.should_update_acl_uploader = True
         else:

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -149,10 +149,8 @@ class FileUploadEntity(UploadEntity):
         if self.use_object_id(self.entity_type) and self.object_id and self.file_exists:
             if (
                 self._is_valid_hash_size_for_file()
-                and not (hasattr(self.file_by_uuid, "acl") and self.file_by_uuid.acl)
-                and not (
-                    hasattr(self.file_by_uuid, "authz") and self.file_by_uuid.authz
-                )
+                and not getattr(self.file_by_uuid, "acl", None)
+                and not getattr(self.file_by_uuid, "authz", None)
             ):
                 self.should_update_acl_and_authz = True
         else:

--- a/sheepdog/transactions/upload/sub_entities.py
+++ b/sheepdog/transactions/upload/sub_entities.py
@@ -147,7 +147,11 @@ class FileUploadEntity(UploadEntity):
 
         # file already indexed and object_id provided: data upload flow
         if self.use_object_id(self.entity_type) and self.object_id and self.file_exists:
-            if self._is_valid_hash_size_for_file():
+            if (
+                self._is_valid_hash_size_for_file()
+                and not self.file_by_uuid.acl
+                and not self.file_by_uuid.authz
+            ):
                 self.should_update_acl_uploader = True
         else:
             self._set_node_and_file_ids()


### PR DESCRIPTION
### Bug Fixes
- Only write acl and authz fields of corresponding Indexd record during data submission iff both fields are empty to begin with. Prevents authz field from being unintentionally populated in commons not using authz.

### Breaking Changes
- Note that this PR will cause Sheepdog behavior to change slightly during a data submission flow in which the acl and/or authz field are previously populated in the corresponding Indexd record and the Indexd uploader field is not null and the Sheepdog submitter does not match the Indexd uploader. While the existing behavior will cause data submission to fail and report an error message to the user, this PR’s changes will mean that data submission can still succeed in this case of populated acl/authz and uploader mismatch. I believe this change in behavior is not problematic in that it would be unexpected in any commons for uploader and (acl and/or authz) to both be populated.