### PR TITLE
(PXP-7094): fix mapping file for any node category ending in "_file" (e.g. "genomic_data_file")

### DIFF
--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -166,6 +166,9 @@ app = Flask(__name__)
 app.logger.setLevel(
     logging.DEBUG if (os.environ.get("GEN3_DEBUG") == "True") else logging.WARNING
 )
+app.logger.propagate = False
+while app.logger.handlers:
+    app.logger.removeHandler(app.logger.handlers[0])
 app.logger.addHandler(get_handler())
 
 setup_default_handlers(app)

--- a/sheepdog/api.py
+++ b/sheepdog/api.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import logging
 
 from flask import Flask, jsonify
 from psqlgraph import PsqlGraphDriver
@@ -162,6 +163,9 @@ app = Flask(__name__)
 
 
 # Setup logger
+app.logger.setLevel(
+    logging.DEBUG if (os.environ.get("GEN3_DEBUG") == "True") else logging.WARNING
+)
 app.logger.addHandler(get_handler())
 
 setup_default_handlers(app)

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -51,8 +51,6 @@ class UploadEntity(EntityBase):
     session.
     """
 
-    DATA_FILE_CATEGORIES = ["data_file", "metadata_file", "index_file"]
-
     def __init__(self, transaction, config=None):
         """
         Args:

--- a/sheepdog/transactions/upload/entity_factory.py
+++ b/sheepdog/transactions/upload/entity_factory.py
@@ -38,7 +38,7 @@ class UploadEntityFactory:
         node_type = doc.get("type")
         node_category = get_node_category(node_type)
 
-        if node_category in UploadEntity.DATA_FILE_CATEGORIES:
+        if node_category.endswith("_file"):
             return FileUploadEntity(transaction, config)
         else:
             return NonFileUploadEntity(transaction, config)

--- a/sheepdog/transactions/upload/entity_factory.py
+++ b/sheepdog/transactions/upload/entity_factory.py
@@ -39,6 +39,12 @@ class UploadEntityFactory:
         node_category = get_node_category(node_type)
 
         if node_category.endswith("_file"):
+            transaction.logger.debug(
+                "Identified %s node as a data file node", node_type
+            )
             return FileUploadEntity(transaction, config)
         else:
+            transaction.logger.debug(
+                "Identified %s node as a non-data file node", node_type
+            )
             return NonFileUploadEntity(transaction, config)


### PR DESCRIPTION
Jira Ticket: [PXP-7094](https://ctds-planx.atlassian.net/browse/PXP-7094)

For reasons pertaining to Explorer functionality, the MIDRC commons dictionary uses more specific `category` names for some of the data file nodes (e.g. `category: genomic_data_file` for the [virus_sequence node](https://github.com/uc-cdis/midrc_dictionary/blob/7ef97f0f1b126f4e4526840983b7553490804539/gdcdictionary/schemas/virus_sequence.yaml#L7)).

This has been causing a data upload/file mapping integration test to fail for [cdis-manifest MIDRC PRs](https://github.com/uc-cdis/cdis-manifest/pull/2267) because a `NonFileUploadEntity` instance is created instead of a `FileUploadEntity` instance that would be responsible for updating `acl`/`authz` in Indexd.

### Bug Fixes
- Fix mapping files for any node category ending in `"_file"`
- Fix duplication of application logging messages by not propagating

### Improvements
- Set application log level based on [`GEN3_DEBUG`](https://github.com/uc-cdis/cloud-automation/blob/a49af964e3b440883c3294f6138295d81855fc86/kube/services/sheepdog/sheepdog-deploy.yaml#L120) environment variable