### PR TITLE
PXP-8123 Fix various TSV arrays bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,6 @@ cdiserrors==0.1.2
 cdislogging==1.0.0
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-gen3datamodel==3.0.2
+gen3datamodel==3.0.3
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient

--- a/sheepdog/utils/transforms/__init__.py
+++ b/sheepdog/utils/transforms/__init__.py
@@ -33,11 +33,18 @@ def parse_bool_from_string(value):
 def parse_list_from_string(value):
     """
     Handle array fields by converting them to a list.
+    Try to cast to float to handle arrays of numbers.
 
     Example:
-        1,2,3 -> ['1','2','3']
+        a,b,c -> ['a','b','c']
+        1,2,3 -> [1,2,3]
     """
-    return [x.strip() for x in value.split(",")]
+    items = [x.strip() for x in value.split(",")]
+    try:
+        items = [float(x) for x in items]
+    except ValueError:
+        pass  # not an array of numbers
+    return items
 
 
 def set_row_type(row):

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -159,7 +159,7 @@ def list_to_comma_string(val, file_format):
         return ""
 
     if isinstance(val, list):
-        val = ",".join(val)
+        val = ",".join((str(x) for x in val))
     return val
 
 

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -153,7 +153,7 @@ def list_to_comma_string(val, file_format):
     """
 
     if val is None:
-        """ If a field is empty we must replace it with an empty string for tsv/csv exports and leave it as None for json exports """
+        """If a field is empty we must replace it with an empty string for tsv/csv exports and leave it as None for json exports"""
         if file_format == "json":
             return val
         return ""


### PR DESCRIPTION
Jira Ticket: [PXP-8123](https://ctds-planx.atlassian.net/browse/PXP-8123)

goes with https://github.com/uc-cdis/gdcdatamodel/pull/33

- bug when submitting array items as TSV: `1,2,3` is parsed as `['1', '2', '3']` and we return `'1' is not of type 'number'`

- bug when exporting array items to TSV:
```
  File "/sheepdog/sheepdog/utils/transforms/graph_to_doc.py", line 162, in list_to_comma_string
    val = ",".join(val)
TypeError: sequence item 0: expected str instance, int found
```

- bug when reporting array items errors to users:
```
  File "/sheepdog/sheepdog/transactions/upload/transaction.py", line 52, in record_errors
    keys = [".".join(error.path)] if error.path else []
TypeError: sequence item 1: expected str instance, int found
```

### Bug Fixes
- Fix bug when submitting array items as TSV
- Fix bug when exporting array items to TSV
- Fix bug when reporting array items errors to users

### Improvements
- Add logging to facilitate debugging validation issues

### Dependency updates
- gdcdatamodel to 3.0.3