### PR TITLE
PXP-9192 Validate format

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-11-01T21:39:46Z",
+  "generated_at": "2021-12-21T20:46:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -166,7 +166,7 @@
       {
         "hashed_secret": "78b4db9b2aec0f0f2d3e38f9278be42b861c9dc3",
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1516,
         "type": "Hex High Entropy String"
       }
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ cdislogging==1.0.0
 google-crc32c==1.1.2
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-gen3datamodel==3.1.0
+gen3datamodel==3.1.1
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient
 -e git+https://github.com/technige/py2neo.git@py2neo-2.0#egg=py2neo

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,8 @@ cdislogging==1.0.0
 google-crc32c==1.1.2
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-gen3datamodel==3.0.3
+# gen3datamodel==3.0.3
+git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/format#egg=gen3datamodel
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient
 -e git+https://github.com/technige/py2neo.git@py2neo-2.0#egg=py2neo

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ xmltodict==0.9.2
 more-itertools==5.0.0
 cdis_oauth2client==1.0.0
 cdispyutils==1.0.4
-datamodelutils==1.0.0
 # required for gen3datamodel, not required for sheepdog
 psqlgraph==3.0.1
 cdiserrors==0.1.2
@@ -36,8 +35,7 @@ cdislogging==1.0.0
 google-crc32c==1.1.2
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-# gen3datamodel==3.0.3
-git+https://git@github.com/uc-cdis/gdcdatamodel.git@fix/format#egg=gen3datamodel
+gen3datamodel==3.1.0
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient
 -e git+https://github.com/technige/py2neo.git@py2neo-2.0#egg=py2neo

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ cdislogging==1.0.0
 google-crc32c==1.1.2
 git+https://git@github.com/NCI-GDC/cdisutils.git@f54e393c89939b2200dfae45c6235cbe2bae1206#egg=cdisutils
 gen3dictionary==2.0.1
-gen3datamodel==3.1.1
+gen3datamodel==3.1.0
 git+https://git@github.com/uc-cdis/indexclient.git@2.0.0#egg=indexclient
 git+https://git@github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient
 -e git+https://github.com/technige/py2neo.git@py2neo-2.0#egg=py2neo

--- a/tests/integration/datadict/schemas/dictionary.json
+++ b/tests/integration/datadict/schemas/dictionary.json
@@ -3706,7 +3706,8 @@
                 "term": {
                     "$ref": "_terms.yaml#/time_between_clamping_and_freezing"
                 },
-                "type": "string"
+                "type": "string",
+                "format": "date-time"
             },
             "shortest_dimension": {
                 "term": {

--- a/tests/integration/datadict/test_vacuous.py
+++ b/tests/integration/datadict/test_vacuous.py
@@ -1,2 +1,0 @@
-def test_vacuous():
-    assert True


### PR DESCRIPTION
Jira Ticket: [PXP-9192](https://ctds-planx.atlassian.net/browse/PXP-9192)

requires https://github.com/uc-cdis/gdcdatamodel/pull/35

### New Features
- Validate `jsonschema` format during submission

### Breaking Changes
- Sheepdog now validates formats. If your dictionary uses formats and you have existing data or submission pipelines that do not respect these formats, this might be a breaking change

### Dependency updates
- `gen3datamodel` to 3.1.0