### PR TITLE
PXP-9266 Split SSL and isolation level tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2022-01-19T22:54:00Z",
+  "generated_at": "2022-01-26T15:40:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -166,7 +166,7 @@
       {
         "hashed_secret": "78b4db9b2aec0f0f2d3e38f9278be42b861c9dc3",
         "is_verified": false,
-        "line_number": 1504,
+        "line_number": 1516,
         "type": "Hex High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-12-21T20:46:37Z",
+  "generated_at": "2022-01-19T22:54:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -166,7 +166,7 @@
       {
         "hashed_secret": "78b4db9b2aec0f0f2d3e38f9278be42b861c9dc3",
         "is_verified": false,
-        "line_number": 1516,
+        "line_number": 1504,
         "type": "Hex High Entropy String"
       }
     ],

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -151,16 +151,22 @@ def app(tmpdir, request):
     return _app
 
 
-@pytest.fixture(params=[False, True, None])
+@pytest.fixture()
 def use_ssl(request):
-    # return False, True, None
-    return request.param
+    try:
+        # one of [False, True, None]
+        return request.param
+    except:
+        return None
 
 
-@pytest.fixture(params=("READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None))
+@pytest.fixture()
 def isolation_level(request):
-    # return 'READ_COMMITTED', 'REPEATABLE_READ', 'SERIALIZABLE', None
-    return request.param
+    try:
+        # one of ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
+        return request.param
+    except:
+        return None
 
 
 @pytest.fixture

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -340,7 +340,7 @@ def put_example_entities_together(client, headers):
     return client.put(path, headers=headers, data=json.dumps(data))
 
 
-def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
+def do_test_post_example_entities_together(client, submitter):
     with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
         case_sid = json.loads(f.read())["submitter_id"]
         print(case_sid)
@@ -354,6 +354,10 @@ def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter
         in resp_data["entities"][0]["errors"][0]["message"]
     )
     assert condition_to_check, resp.data
+
+
+def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
+    do_test_post_example_entities_together(client, submitter)
 
 
 def test_dictionary_list_entries(client, pg_driver, cgci_blgsp, submitter):
@@ -505,7 +509,7 @@ def test_disallow_cross_project_references(client, pg_driver, cgci_blgsp, submit
     assert resp.status_code == 400, resp.data
 
 
-def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
+def do_test_delete_entity(client, submitter):
     resp = client.put(
         BLGSP_PATH,
         headers=submitter,
@@ -522,6 +526,10 @@ def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
     path = BLGSP_PATH + "entities/" + did
     resp = client.delete(path, headers=submitter)
     assert resp.status_code == 200, resp.data
+
+
+def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
+    do_test_delete_entity(client, submitter)
 
 
 def test_catch_internal_errors(monkeypatch, client, pg_driver, cgci_blgsp, submitter):
@@ -698,7 +706,7 @@ def test_valid_file_index(
     assert index_client.get(sur_entity["id"]), "No indexd document created"
 
 
-def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
+def do_test_submit_valid_tsv(client, submitter):
     """
     Test that we can submit a valid TSV file
     """
@@ -727,6 +735,10 @@ def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
     headers["Content-Type"] = "text/tsv"
     resp = client.put(BLGSP_PATH, headers=headers, data=data)
     assert resp.status_code == 200, resp.data
+
+
+def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
+    do_test_submit_valid_tsv(client, submitter)
 
 
 def test_submit_valid_csv(client, pg_driver, cgci_blgsp, submitter):

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -710,9 +710,7 @@ def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
     }
 
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()
@@ -792,9 +790,7 @@ def test_can_submit_with_asterisk_tsv(client, pg_driver, cgci_blgsp, submitter):
         "*projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
     }
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()
@@ -1038,9 +1034,7 @@ def test_duplicate_submission(app, pg_driver, cgci_blgsp, submitter):
     }
 
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()
@@ -1149,9 +1143,7 @@ def test_zero_decimal_float(client, pg_driver, cgci_blgsp, submitter):
     }
 
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()
@@ -1302,9 +1294,7 @@ def test_update_to_null_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
     }
 
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()
@@ -1368,9 +1358,7 @@ def test_update_to_null_invalid_tsv(client, pg_driver, cgci_blgsp, submitter):
     }
 
     # convert to TSV (save to file)
-    file_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data/experiment_tmp.tsv"
-    )
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
     with open(file_path, "w") as f:
         dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
         dw.writeheader()

--- a/tests/integration/datadict/test_ssl_and_isolation_level.py
+++ b/tests/integration/datadict/test_ssl_and_isolation_level.py
@@ -3,15 +3,12 @@ Copy of a few functional tests in order to test that SSL and isolation level
 settings work.
 """
 
-import csv
-import json
 import pytest
-import os
 
-from .submission.test_endpoints import (
-    BLGSP_PATH,
-    DATA_DIR,
-    post_example_entities_together,
+from tests.integration.datadict.submission.test_endpoints import (
+    do_test_post_example_entities_together,
+    do_test_delete_entity,
+    do_test_submit_valid_tsv,
     do_test_export,
 )
 
@@ -23,71 +20,19 @@ ISOLATION_LEVELS = ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
-        case_sid = json.loads(f.read())["submitter_id"]
-        print(case_sid)
-    resp = post_example_entities_together(client, submitter)
-    resp_data = json.loads(resp.data)
-    condition_to_check = (resp.status_code == 201 and resp.data) or (
-        resp.status_code == 400
-        and "already exists in the DB"
-        in resp_data["entities"][0]["errors"][0]["message"]
-    )
-    assert condition_to_check, resp.data
+    do_test_post_example_entities_together(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.put(
-        BLGSP_PATH,
-        headers=submitter,
-        data=json.dumps(
-            {
-                "type": "experiment",
-                "submitter_id": "BLGSP-71-06-00019",
-                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
-            }
-        ),
-    )
-    assert resp.status_code == 200, resp.data
-    did = resp.json["entities"][0]["id"]
-    path = BLGSP_PATH + "entities/" + did
-    resp = client.delete(path, headers=submitter)
-    assert resp.status_code == 200, resp.data
+    do_test_delete_entity(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
-    """
-    Test that we can submit a valid TSV file
-    """
-
-    data = {
-        "type": "experiment",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
-    }
-
-    # convert to TSV (save to file)
-    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
-    with open(file_path, "w") as f:
-        dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
-        dw.writeheader()
-        dw.writerow(data)
-
-    # read the TSV data
-    data = None
-    with open(file_path, "r") as f:
-        data = f.read()
-    os.remove(file_path)  # clean up (delete file)
-    assert data
-
-    headers = submitter
-    headers["Content-Type"] = "text/tsv"
-    resp = client.put(BLGSP_PATH, headers=headers, data=data)
-    assert resp.status_code == 200, resp.data
+    do_test_submit_valid_tsv(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)

--- a/tests/integration/datadict/test_ssl_and_isolation_level.py
+++ b/tests/integration/datadict/test_ssl_and_isolation_level.py
@@ -1,0 +1,98 @@
+"""
+Copy of a few functional tests in order to test that SSL and isolation level
+settings work.
+"""
+
+import csv
+import json
+import pytest
+import os
+
+from .submission.test_endpoints import (
+    BLGSP_PATH,
+    DATA_DIR,
+    post_example_entities_together,
+    do_test_export,
+)
+
+
+USE_SSL = [False, True, None]
+ISOLATION_LEVELS = ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
+        print(case_sid)
+    resp = post_example_entities_together(client, submitter)
+    resp_data = json.loads(resp.data)
+    condition_to_check = (resp.status_code == 201 and resp.data) or (
+        resp.status_code == 400
+        and "already exists in the DB"
+        in resp_data["entities"][0]["errors"][0]["message"]
+    )
+    assert condition_to_check, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
+    resp = client.put(
+        BLGSP_PATH,
+        headers=submitter,
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
+    assert resp.status_code == 200, resp.data
+    did = resp.json["entities"][0]["id"]
+    path = BLGSP_PATH + "entities/" + did
+    resp = client.delete(path, headers=submitter)
+    assert resp.status_code == 200, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
+    """
+    Test that we can submit a valid TSV file
+    """
+
+    data = {
+        "type": "experiment",
+        "submitter_id": "BLGSP-71-06-00019",
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
+    }
+
+    # convert to TSV (save to file)
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
+    with open(file_path, "w") as f:
+        dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
+        dw.writeheader()
+        dw.writerow(data)
+
+    # read the TSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path)  # clean up (delete file)
+    assert data
+
+    headers = submitter
+    headers["Content-Type"] = "text/tsv"
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_export_all_node_types(
+    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
+):
+    do_test_export(client, pg_driver, submitter, "experimental_metadata", "tsv")

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -149,16 +149,22 @@ def app(tmpdir, request):
     return _app
 
 
-@pytest.fixture(params=[None, False, True])
+@pytest.fixture()
 def use_ssl(request):
-    # return None, False, True
-    return request.param
+    try:
+        # one of [False, True, None]
+        return request.param
+    except:
+        return None
 
 
-@pytest.fixture(params=("READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None))
+@pytest.fixture()
 def isolation_level(request):
-    # return 'READ_COMMITTED', 'REPEATABLE_READ', 'SERIALIZABLE', None
-    return request.param
+    try:
+        # one of ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
+        return request.param
+    except:
+        return None
 
 
 @pytest.fixture

--- a/tests/integration/datadictwithobjid/test_ssl_and_isolation_level.py
+++ b/tests/integration/datadictwithobjid/test_ssl_and_isolation_level.py
@@ -3,15 +3,14 @@ Copy of a few functional tests in order to test that SSL and isolation level
 settings work.
 """
 
-import csv
-import json
 import pytest
-import os
 
-from .submission.test_endpoints import (
-    BLGSP_PATH,
-    DATA_DIR,
-    post_example_entities_together,
+from tests.integration.datadictwithobjid.submission.test_endpoints import (
+    do_test_post_example_entities_together,
+)
+from tests.integration.datadict.submission.test_endpoints import (
+    do_test_delete_entity,
+    do_test_submit_valid_tsv,
     do_test_export,
 )
 
@@ -23,71 +22,19 @@ ISOLATION_LEVELS = ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
-    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
-        case_sid = json.loads(f.read())["submitter_id"]
-        print(case_sid)
-    resp = post_example_entities_together(client, submitter)
-    resp_data = json.loads(resp.data)
-    condition_to_check = (resp.status_code == 201 and resp.data) or (
-        resp.status_code == 400
-        and "already exists in the DB"
-        in resp_data["entities"][0]["errors"][0]["message"]
-    )
-    assert condition_to_check, resp.data
+    do_test_post_example_entities_together(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
-    resp = client.put(
-        BLGSP_PATH,
-        headers=submitter,
-        data=json.dumps(
-            {
-                "type": "experiment",
-                "submitter_id": "BLGSP-71-06-00019",
-                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
-            }
-        ),
-    )
-    assert resp.status_code == 200, resp.data
-    did = resp.json["entities"][0]["id"]
-    path = BLGSP_PATH + "entities/" + did
-    resp = client.delete(path, headers=submitter)
-    assert resp.status_code == 200, resp.data
+    do_test_delete_entity(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
 @pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
 def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
-    """
-    Test that we can submit a valid TSV file
-    """
-
-    data = {
-        "type": "experiment",
-        "submitter_id": "BLGSP-71-06-00019",
-        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
-    }
-
-    # convert to TSV (save to file)
-    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
-    with open(file_path, "w") as f:
-        dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
-        dw.writeheader()
-        dw.writerow(data)
-
-    # read the TSV data
-    data = None
-    with open(file_path, "r") as f:
-        data = f.read()
-    os.remove(file_path)  # clean up (delete file)
-    assert data
-
-    headers = submitter
-    headers["Content-Type"] = "text/tsv"
-    resp = client.put(BLGSP_PATH, headers=headers, data=data)
-    assert resp.status_code == 200, resp.data
+    do_test_submit_valid_tsv(client, submitter)
 
 
 @pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)

--- a/tests/integration/datadictwithobjid/test_ssl_and_isolation_level.py
+++ b/tests/integration/datadictwithobjid/test_ssl_and_isolation_level.py
@@ -1,0 +1,98 @@
+"""
+Copy of a few functional tests in order to test that SSL and isolation level
+settings work.
+"""
+
+import csv
+import json
+import pytest
+import os
+
+from .submission.test_endpoints import (
+    BLGSP_PATH,
+    DATA_DIR,
+    post_example_entities_together,
+    do_test_export,
+)
+
+
+USE_SSL = [False, True, None]
+ISOLATION_LEVELS = ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_post_example_entities_together(client, pg_driver, cgci_blgsp, submitter):
+    with open(os.path.join(DATA_DIR, "case.json"), "r") as f:
+        case_sid = json.loads(f.read())["submitter_id"]
+        print(case_sid)
+    resp = post_example_entities_together(client, submitter)
+    resp_data = json.loads(resp.data)
+    condition_to_check = (resp.status_code == 201 and resp.data) or (
+        resp.status_code == 400
+        and "already exists in the DB"
+        in resp_data["entities"][0]["errors"][0]["message"]
+    )
+    assert condition_to_check, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_delete_entity(client, pg_driver, cgci_blgsp, submitter):
+    resp = client.put(
+        BLGSP_PATH,
+        headers=submitter,
+        data=json.dumps(
+            {
+                "type": "experiment",
+                "submitter_id": "BLGSP-71-06-00019",
+                "projects": {"id": "daa208a7-f57a-562c-a04a-7a7c77542c98"},
+            }
+        ),
+    )
+    assert resp.status_code == 200, resp.data
+    did = resp.json["entities"][0]["id"]
+    path = BLGSP_PATH + "entities/" + did
+    resp = client.delete(path, headers=submitter)
+    assert resp.status_code == 200, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_submit_valid_tsv(client, pg_driver, cgci_blgsp, submitter):
+    """
+    Test that we can submit a valid TSV file
+    """
+
+    data = {
+        "type": "experiment",
+        "submitter_id": "BLGSP-71-06-00019",
+        "projects.id": "daa208a7-f57a-562c-a04a-7a7c77542c98",
+    }
+
+    # convert to TSV (save to file)
+    file_path = os.path.join(DATA_DIR, "experiment_tmp.tsv")
+    with open(file_path, "w") as f:
+        dw = csv.DictWriter(f, sorted(data.keys()), delimiter="\t")
+        dw.writeheader()
+        dw.writerow(data)
+
+    # read the TSV data
+    data = None
+    with open(file_path, "r") as f:
+        data = f.read()
+    os.remove(file_path)  # clean up (delete file)
+    assert data
+
+    headers = submitter
+    headers["Content-Type"] = "text/tsv"
+    resp = client.put(BLGSP_PATH, headers=headers, data=data)
+    assert resp.status_code == 200, resp.data
+
+
+@pytest.mark.parametrize("use_ssl", USE_SSL, indirect=True)
+@pytest.mark.parametrize("isolation_level", ISOLATION_LEVELS, indirect=True)
+def test_export_all_node_types(
+    client, pg_driver, cgci_blgsp, submitter, require_index_exists_off
+):
+    do_test_export(client, pg_driver, submitter, "experimental_metadata", "tsv")


### PR DESCRIPTION
Jira Ticket: [PXP-9266](https://ctds-planx.atlassian.net/browse/PXP-9266)

### Improvements
- Split "use SSL" and "isolation level" unit tests into their own file. The previous parametrization caused the tests to take 30+ min to run, because all tests that use the `pg_driver` fixture were ran 12 times
