### PR TITLE
Catch error instead of 500

### DIFF
--- a/sheepdog/blueprint/routes/views/program/__init__.py
+++ b/sheepdog/blueprint/routes/views/program/__init__.py
@@ -195,7 +195,10 @@ def create_project(program):
         doc.pop("state", None)
         doc.pop("released", None)
 
-        node.props.update(doc)
+        try:
+            node.props.update(doc)
+        except AttributeError as e:
+            raise UserError(f"ERROR: {e}")
 
         res_doc = dict(
             {"type": "project", "programs": {"id": program_node.node_id}}, **doc

--- a/sheepdog/utils/__init__.py
+++ b/sheepdog/utils/__init__.py
@@ -311,7 +311,7 @@ def get_suggestion(value, choices):
             message = " Did you mean '{}'?".format(suggestion)
         else:
             message = ""
-    except:  # pylint: disable=bare-except
+    except Exception:
         pass
     return message
 

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -178,7 +178,7 @@ class BcrXmlToJsonParser(object):
             result = root.xpath(path, namespaces=self.namespaces)
         except etree.XPathEvalError:
             result = []
-        except:
+        except Exception:
             raise
         rlen = len(result)
         if rlen < 1 and expected:

--- a/tests/integration/datadict/conftest.py
+++ b/tests/integration/datadict/conftest.py
@@ -156,7 +156,7 @@ def use_ssl(request):
     try:
         # one of [False, True, None]
         return request.param
-    except:
+    except Exception:
         return None
 
 
@@ -165,7 +165,7 @@ def isolation_level(request):
     try:
         # one of ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
         return request.param
-    except:
+    except Exception:
         return None
 
 

--- a/tests/integration/datadict/submission/test_endpoints.py
+++ b/tests/integration/datadict/submission/test_endpoints.py
@@ -545,7 +545,7 @@ def test_catch_internal_errors(monkeypatch, client, pg_driver, cgci_blgsp, submi
     try:
         r = put_example_entities_together(client, submitter)
         assert len(r.json["transactional_errors"]) == 1, r.data
-    except:
+    except Exception:
         raise
 
 

--- a/tests/integration/datadictwithobjid/conftest.py
+++ b/tests/integration/datadictwithobjid/conftest.py
@@ -154,7 +154,7 @@ def use_ssl(request):
     try:
         # one of [False, True, None]
         return request.param
-    except:
+    except Exception:
         return None
 
 
@@ -163,7 +163,7 @@ def isolation_level(request):
     try:
         # one of ["READ_COMMITTED", "REPEATABLE_READ", "SERIALIZABLE", None]
         return request.param
-    except:
+    except Exception:
         return None
 
 

--- a/tests/integration/datadictwithobjid/submission/test_endpoints.py
+++ b/tests/integration/datadictwithobjid/submission/test_endpoints.py
@@ -580,7 +580,7 @@ def test_catch_internal_errors(monkeypatch, client, pg_driver, cgci_blgsp, submi
     try:
         r = put_example_entities_together(client, submitter)
         assert len(r.json["transactional_errors"]) == 1, r.data
-    except:
+    except Exception:
         raise
 
 


### PR DESCRIPTION
Catch this error that causes Sheepdog to return a 500, and return a 400 instead:
```
  File "/sheepdog/sheepdog/blueprint/routes/views/program/__init__.py", line 198, in create_project
    node.props.update(doc)
  File "/usr/local/lib/python3.6/site-packages/psqlgraph/attributes.py", line 76, in update
    raise AttributeError("{} has no property {}".format(self.source, key))
AttributeError: <Project(029d0e6b-781b-52cc-ba36-748639545662)> has no property programs
```
