### PR TITLE
PXP-10952 Fix validation issue when submitting null values

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -663,13 +663,12 @@ psqlgraph = ">=3.0.0"
 
 [[package]]
 name = "dictionaryutils"
-version = "3.4.5"
+version = "3.4.6"
 description = "Python wrapper and metaschema for datadictionary."
-category = "main"
 optional = false
 python-versions = ">=3.6,<3.10"
 files = [
-    {file = "dictionaryutils-3.4.5.tar.gz", hash = "sha256:3348b369a67a68690e020adb9add358c40327c97ec4917f460cf3ba5cd263696"},
+    {file = "dictionaryutils-3.4.6.tar.gz", hash = "sha256:b834bbb802d930fefae99ad155a0b07eef1a07f87c0b3aaef220dc20dda73a9c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authlib = "*" # let authutils decide which version we're using
 authutils = ">=6.0.0"
 boto = ">=2.39.0"
 datamodelutils = ">=1.0.0"
-dictionaryutils = ">=3.2.0"
+dictionaryutils = ">=3.4.6"
 envelopes = ">=0.4"
 # flask 2.2.0 removes `RequestContext.preserved` which we use in a workaround in `conftest.client`
 Flask = ">=1.1.1,<2.2.0"


### PR DESCRIPTION
Jira Ticket: [PXP-10952](https://ctds-planx.atlassian.net/browse/PXP-10952)

see https://github.com/uc-cdis/dictionaryutils/pull/85

### Bug Fixes
- Fix validation issue when submitting null values allowed by a `oneOf/anyOf` dictionary property definition


[PXP-10952]: https://ctds-planx.atlassian.net/browse/PXP-10952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ