### PR TITLE
[Fix] Sheepdog populating version info incorrectly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ COPY --chown=gen3:gen3 . /${appname}
 
 RUN poetry install -vv --without dev --no-interaction
 
-RUN git config --global --add safe.directory /${appname} && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" > /${appname}/version_data.py \
-    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >> /${appname}/version_data.py
+RUN git config --global --add safe.directory ${appname} && COMMIT=`git rev-parse HEAD` && echo "COMMIT=\"${COMMIT}\"" > ${appname}/version_data.py \
+    && VERSION=`git describe --always --tags` && echo "VERSION=\"${VERSION}\"" >> ${appname}/version_data.py
 
 # Final stage
 FROM base

--- a/sheepdog/version_data.py
+++ b/sheepdog/version_data.py
@@ -1,2 +1,2 @@
-VERSION = ""
-COMMIT = ""
+VERSION = "x.y.z"
+COMMIT = "random"

--- a/sheepdog/version_data.py
+++ b/sheepdog/version_data.py
@@ -1,2 +1,2 @@
-VERSION = "x.y.z"
-COMMIT = "random"
+VERSION = ""
+COMMIT = ""


### PR DESCRIPTION
Link to JIRA ticket if there is one: [MIDRC-938](https://ctds-planx.atlassian.net/browse/MIDRC-938)

### Bug Fixes
* Fixed: `version_data.py` was being updated at an incorrect location during docker image build


[MIDRC-938]: https://ctds-planx.atlassian.net/browse/MIDRC-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ