### PR TITLE
Chore/remove gdc from docstrings

### DIFF
--- a/openapi/swagger.yml
+++ b/openapi/swagger.yml
@@ -652,11 +652,10 @@ paths:
       - dry run
   /v0/submission/<program>/<project>/entities/<entity_id_string>:
     get:
-      description: Retrieve existing GDC entities by ID. The return type of a HTTP
-        `get` on this endpoint is a JSON array containing JSON object elements, each
-        corresponding to a provided ID. Return results are unordered. If any ID is
-        not found in the database, a status code of 404 is returned with the missing
-        IDs.
+      description: Retrieve existing entities by ID. The return type of a HTTP `get`
+        on this endpoint is a JSON array containing JSON object elements, each corresponding
+        to a provided ID. Return results are unordered. If any ID is not found in
+        the database, a status code of 404 is returned with the missing IDs.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -691,9 +690,9 @@ paths:
       - entity
   /v0/submission/<program>/<project>/entities/<ids>:
     delete:
-      description: Delete existing GDC entities. Using the :http:method:`delete` on
-        a project's endpoint will *completely delete* an entity. The GDC does not
-        allow deletions or creations that would leave nodes without parents, i.e.
+      description: Delete existing entities. Using the :http:method:`delete` on a
+        project's endpoint will *completely delete* an entity. The Gen3 commons does
+        not allow deletions or creations that would leave nodes without parents, i.e.
         nodes that do not have an entity from which they were derived. To prevent
         catastrophic mistakes, the current philosophy is to disallow automatic cascading
         of deletes. However, to inform a user which entities must be deleted for the
@@ -713,7 +712,7 @@ paths:
         required: true
         type: string
       - description: A comma separated list of ids specifying the entities to delete.
-          These ids must be official GDC ids.
+          These ids must be official ids.
         in: path
         name: ids
         required: true
@@ -737,9 +736,9 @@ paths:
       - entity
   /v0/submission/<program>/<project>/entities/_dry_run/<ids>:
     delete:
-      description: Delete existing GDC entities. Using the :http:method:`delete` on
-        a project's endpoint will *completely delete* an entity. The GDC does not
-        allow deletions or creations that would leave nodes without parents, i.e.
+      description: Delete existing entities. Using the :http:method:`delete` on a
+        project's endpoint will *completely delete* an entity. The Gen3 commons does
+        not allow deletions or creations that would leave nodes without parents, i.e.
         nodes that do not have an entity from which they were derived. To prevent
         catastrophic mistakes, the current philosophy is to disallow automatic cascading
         of deletes. However, to inform a user which entities must be deleted for the
@@ -759,7 +758,7 @@ paths:
         required: true
         type: string
       - description: A comma separated list of ids specifying the entities to delete.
-          These ids must be official GDC ids.
+          These ids must be official ids.
         in: path
         name: ids
         required: true
@@ -922,7 +921,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -960,7 +959,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -998,7 +997,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1041,7 +1040,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1084,7 +1083,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1122,7 +1121,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1160,7 +1159,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1203,7 +1202,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true
@@ -1574,9 +1573,9 @@ paths:
       - dry run
   /v0/submission/<program>/<project>/submit:
     post:
-      description: Submit a project. Submitting a project means that the GDC can make
-        all metadata that *currently* exists in the project public in every GDC index
-        built after the project is released.
+      description: Submit a project. Submitting a project means that the Gen3 commons
+        can make all metadata that *currently* exists in the project public in every
+        index built after the project is released.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1601,9 +1600,9 @@ paths:
       tags:
       - project
     put:
-      description: Submit a project. Submitting a project means that the GDC can make
-        all metadata that *currently* exists in the project public in every GDC index
-        built after the project is released.
+      description: Submit a project. Submitting a project means that the Gen3 commons
+        can make all metadata that *currently* exists in the project public in every
+        index built after the project is released.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1629,9 +1628,9 @@ paths:
       - project
   /v0/submission/<program>/<project>/submit/_dry_run:
     post:
-      description: Submit a project. Submitting a project means that the GDC can make
-        all metadata that *currently* exists in the project public in every GDC index
-        built after the project is released.
+      description: Submit a project. Submitting a project means that the Gen3 commons
+        can make all metadata that *currently* exists in the project public in every
+        index built after the project is released.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1656,9 +1655,9 @@ paths:
       tags:
       - dry run
     put:
-      description: Submit a project. Submitting a project means that the GDC can make
-        all metadata that *currently* exists in the project public in every GDC index
-        built after the project is released.
+      description: Submit a project. Submitting a project means that the Gen3 commons
+        can make all metadata that *currently* exists in the project public in every
+        index built after the project is released.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -2089,9 +2088,9 @@ paths:
       - dictionary
   /v0/submission/admin/<program>/<project>/entities/<ids>/to_delete/<to_delete>:
     delete:
-      description: Delete existing GDC entities. Using the :http:method:`delete` on
-        a project's endpoint will *completely delete* an entity. The GDC does not
-        allow deletions or creations that would leave nodes without parents, i.e.
+      description: Delete existing entities. Using the :http:method:`delete` on a
+        project's endpoint will *completely delete* an entity. The Gen3 commons does
+        not allow deletions or creations that would leave nodes without parents, i.e.
         nodes that do not have an entity from which they were derived. To prevent
         catastrophic mistakes, the current philosophy is to disallow automatic cascading
         of deletes. However, to inform a user which entities must be deleted for the
@@ -2111,7 +2110,7 @@ paths:
         required: true
         type: string
       - description: A comma separated list of ids specifying the entities to delete.
-          These ids must be official GDC ids.
+          These ids must be official ids.
         in: path
         name: ids
         required: true
@@ -2149,7 +2148,7 @@ paths:
         name: project
         required: true
         type: string
-      - description: The GDC id of the file to upload.
+      - description: The id of the file to upload.
         in: path
         name: uuid
         required: true

--- a/openapi/swagger.yml
+++ b/openapi/swagger.yml
@@ -1573,9 +1573,7 @@ paths:
       - dry run
   /v0/submission/<program>/<project>/submit:
     post:
-      description: Submit a project. Submitting a project means that the Gen3 commons
-        can make all metadata that *currently* exists in the project public in every
-        index built after the project is released.
+      description: Submit a project.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1600,9 +1598,7 @@ paths:
       tags:
       - project
     put:
-      description: Submit a project. Submitting a project means that the Gen3 commons
-        can make all metadata that *currently* exists in the project public in every
-        index built after the project is released.
+      description: Submit a project.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1628,9 +1624,7 @@ paths:
       - project
   /v0/submission/<program>/<project>/submit/_dry_run:
     post:
-      description: Submit a project. Submitting a project means that the Gen3 commons
-        can make all metadata that *currently* exists in the project public in every
-        index built after the project is released.
+      description: Submit a project.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.
@@ -1655,9 +1649,7 @@ paths:
       tags:
       - dry run
     put:
-      description: Submit a project. Submitting a project means that the Gen3 commons
-        can make all metadata that *currently* exists in the project public in every
-        index built after the project is released.
+      description: Submit a project.
       parameters:
       - description: The program to which the submitter belongs and in which the entities
           will be created. The `program` is the human-readable name, e.g. TCGA.

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -754,10 +754,6 @@ def create_submit_project_viewer(dry_run=False):
         """
         Submit a project.
 
-        Submitting a project means that the Gen3 commons can make all metadata that
-        *currently* exists in the project public in every index built after
-        the project is released.
-
         Summary:
             Submit a project
 

--- a/sheepdog/blueprint/routes/views/program/project.py
+++ b/sheepdog/blueprint/routes/views/program/project.py
@@ -245,7 +245,7 @@ def get_project_dictionary_entry(program, project, entry):
 @auth.authorize_for_project(ROLES["READ"])
 def get_entities_by_id(program, project, entity_id_string):
     """
-    Retrieve existing GDC entities by ID.
+    Retrieve existing entities by ID.
 
     The return type of a HTTP `get` on this endpoint is a JSON array
     containing JSON object elements, each corresponding to a provided ID.
@@ -297,12 +297,12 @@ def create_delete_entities_viewer(dry_run=False):
     @auth.authorize_for_project(ROLES["DELETE"])
     def delete_entities(program, project, ids, to_delete=None):
         """
-        Delete existing GDC entities.
+        Delete existing entities.
 
         Using the :http:method:`delete` on a project's endpoint will
         *completely delete* an entity.
 
-        The GDC does not allow deletions or creations that would leave nodes
+        The Gen3 commons does not allow deletions or creations that would leave nodes
         without parents, i.e. nodes that do not have an entity from which they
         were derived. To prevent catastrophic mistakes, the current philosophy
         is to disallow automatic cascading of deletes. However, to inform a
@@ -318,7 +318,7 @@ def create_delete_entities_viewer(dry_run=False):
         Args:
             program (str): |program_id|
             project (str): |project_id|
-            ids (str): A comma separated list of ids specifying the entities to delete. These ids must be official GDC ids.
+            ids (str): A comma separated list of ids specifying the entities to delete. These ids must be official ids.
 
         Query Args:
             to_delete (bool): Set the to_delete sysan as true or false. If none, then don't try to set the sysan, and instead delete the node.
@@ -481,7 +481,7 @@ def create_files_viewer(dry_run=False, reassign=False):
     def file_operations(program, project, file_uuid):
         """
         Handle molecular file operations.  This will only be available once the
-        user has created a file entity with GDC id ``uuid`` via the
+        user has created a file entity with id ``uuid`` via the
         ``/<program>/<project>/`` endppoint.
 
         This endpoint is an S3 compatible endpoint as described here:
@@ -520,7 +520,7 @@ def create_files_viewer(dry_run=False, reassign=False):
         Args:
             program (str): |program_id|
             project (str): |project_id|
-            uuid (str): The GDC id of the file to upload.
+            uuid (str): The id of the file to upload.
 
         Responses:
             200: Success.
@@ -754,8 +754,8 @@ def create_submit_project_viewer(dry_run=False):
         """
         Submit a project.
 
-        Submitting a project means that the GDC can make all metadata that
-        *currently* exists in the project public in every GDC index built after
+        Submitting a project means that the Gen3 commons can make all metadata that
+        *currently* exists in the project public in every index built after
         the project is released.
 
         Summary:

--- a/sheepdog/transactions/deletion/entity.py
+++ b/sheepdog/transactions/deletion/entity.py
@@ -154,7 +154,7 @@ class DeletionEntity(EntityBase):
             message = (
                 "This node has file_state '{file_state}'. "
                 "Deletion is disallowed for entities that have "
-                "raw data uploaded to the GDC.  In order to delete "
+                "raw data uploaded to the Gen3 commons.  In order to delete "
                 "this node you must first delete the raw data with "
                 "the Data Transfer Tool.".format(file_state=self.node.file_state)
             )

--- a/sheepdog/transactions/submission/transaction.py
+++ b/sheepdog/transactions/submission/transaction.py
@@ -152,7 +152,7 @@ class SubmissionTransaction(TransactionBase):
     def send_submission_notification_email(self):
         """Sends an email notification
 
-        This is used in the GDC to notify the user services team
+        This is used in the Gen3 commons to notify the user services team
         about submitting a project
         """
 

--- a/sheepdog/transactions/transaction_base.py
+++ b/sheepdog/transactions/transaction_base.py
@@ -33,7 +33,7 @@ class MissingNode(object):
 
 class TransactionBase(object):
     """
-    Parent class for GDC API transactions.
+    Parent class for sheepdog API transactions.
 
     * Children must define:
 

--- a/sheepdog/transactions/upload/entity.py
+++ b/sheepdog/transactions/upload/entity.py
@@ -124,7 +124,7 @@ class UploadEntity(EntityBase):
                 return self.record_error(
                     (
                         "There are no unique keys defined on type {} except"
-                        " for the official GDC id.  To upload this entity you"
+                        " for the official id.  To upload this entity you"
                         " must add a UUID"
                     ).format(self.entity_type),
                     keys=["id"],

--- a/sheepdog/transactions/upload/transaction.py
+++ b/sheepdog/transactions/upload/transaction.py
@@ -62,7 +62,7 @@ class UploadTransaction(TransactionBase):
         self.json_validator = validators.GDCJSONValidator()
 
         # The dbGapXReferencer conditionally requires cases to exist in
-        # dbGaP prior to submission to the GDC
+        # dbGaP prior to submission to the Gen3 commons
         self.dbgap_x_referencer = dbgap.dbGaPXReferencer(
             self.db_driver, self.logger, proxies=self.external_proxies
         )
@@ -433,7 +433,7 @@ class BulkUploadTransaction(TransactionBase):
                         type=EntityErrors.NOT_UNIQUE,
                     )
 
-        # Check GDC ids
+        # Check entity ids
         for ID in dup_ids.keys():
             for entity in self.entities:
                 if entity.entity_id == ID:

--- a/sheepdog/utils/__init__.py
+++ b/sheepdog/utils/__init__.py
@@ -90,7 +90,7 @@ def _get_links_delimited(link, exclude_id):
     """
     link_template = []
     target_schema = dictionary.schema[link["target_type"]]
-    # default key for link is the GDC ID
+    # default key for link is the entity ID
     if not exclude_id:
         link_template.append("id")
 

--- a/sheepdog/utils/transforms/bcr_xml_to_json.py
+++ b/sheepdog/utils/transforms/bcr_xml_to_json.py
@@ -128,7 +128,7 @@ def to_bool(val):
 class BcrXmlToJsonParser(object):
     def __init__(self, project):
         """
-        Create a parser to convert XML to GDC JSON.
+        Create a parser to convert XML to JSON.
 
         Args:
             project (str): the id of the project node to link cases to

--- a/sheepdog/utils/transforms/graph_to_doc.py
+++ b/sheepdog/utils/transforms/graph_to_doc.py
@@ -269,7 +269,7 @@ def _get_links_delimited(link, exclude_id):
     link_template = []
     target_schema = dictionary.schema[link["target_type"]]
 
-    # default key for link is the GDC ID
+    # default key for link is the ID
     if not exclude_id:
         link_template.append("id")
 


### PR DESCRIPTION
This slack thread show some motivation for updating the sheepdog api documentation:
https://cdis.slack.com/archives/C0294A7KVE0/p1742827500241829


### New Features

### Breaking Changes

### Bug Fixes

### Improvements

* Remove references to `GDC` in docstrings and comments. 

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
